### PR TITLE
resolve naming conflict in build-and-test that prevents its use in checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ on:
 
 
 jobs:
-  build-and-test:
+  build-and-testExpected:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
to resolve the issue with PR checks hanging