### PR TITLE
CLI Support for Specification of Namespace Prefixes and Version #s

### DIFF
--- a/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGenerator.java
@@ -118,6 +118,23 @@ public class PythonCodeGenerator extends AbstractExternalGenerator {
         this.projectName = projectName;
     }
 
+    /**
+     * Optional prefix prepended to every namespace during generation.
+     * When set, a Rosetta namespace "cdm.x.y" becomes "finos.cdm.x.y" in all
+     * generated Python paths, bundle names, and import statements.
+     */
+    private String namespacePrefix = null;
+
+    /**
+     * Sets the namespace prefix. When not set (or set to null), namespaces are
+     * used as-is from the Rosetta model.
+     *
+     * @param namespacePrefix the prefix to prepend, or null for default behaviour
+     */
+    public void setNamespacePrefix(String namespacePrefix) {
+        this.namespacePrefix = namespacePrefix;
+    }
+
     @Override
     public Map<String, ? extends CharSequence> beforeAllGenerate(ResourceSet set,
             Collection<? extends RosettaModel> models, String version) {
@@ -131,14 +148,15 @@ public class PythonCodeGenerator extends AbstractExternalGenerator {
         }
         LOGGER.debug("Processing module: {}", model.getName());
 
-        String nameSpace = PythonCodeGeneratorUtil.getNamespace(model);
+        String effectiveModelName = (namespacePrefix != null && !namespacePrefix.isBlank())
+                ? namespacePrefix + "." + model.getName()
+                : model.getName();
+        String nameSpace = effectiveModelName.split("\\.")[0];
         PythonCodeGeneratorContext context = contexts.get(nameSpace);
         if (context == null) {
             context = new PythonCodeGeneratorContext();
             contexts.put(nameSpace, context);
         }
-
-        String cleanVersion = PythonCodeGeneratorUtil.cleanVersion(version);
 
         Map<String, CharSequence> result = new HashMap<>();
 
@@ -153,21 +171,22 @@ public class PythonCodeGenerator extends AbstractExternalGenerator {
                 .map(Function.class::cast).collect(Collectors.toList());
 
         if (!rosettaClasses.isEmpty() || !rosettaEnums.isEmpty() || !rosettaFunctions.isEmpty()) {
-            context.addSubfolder(model.getName());
+            context.addSubfolder(effectiveModelName);
             if (!rosettaFunctions.isEmpty()) {
-                context.addSubfolder(model.getName() + ".functions");
+                context.addSubfolder(effectiveModelName + ".functions");
             }
         }
 
         Map<String, CharSequence> currentObjects = context.getObjects();
-        currentObjects.putAll(pojoGenerator.generate(rosettaClasses, cleanVersion, context));
-        result.putAll(enumGenerator.generate(rosettaEnums, cleanVersion));
-        Map<String, String> currentFunctions = funcGenerator.generate(rosettaFunctions, cleanVersion, context);
+        currentObjects.putAll(pojoGenerator.generate(rosettaClasses, context, namespacePrefix));
+        result.putAll(enumGenerator.generate(rosettaEnums, namespacePrefix));
+        Map<String, String> currentFunctions = funcGenerator.generate(rosettaFunctions, context, namespacePrefix);
         currentObjects.putAll(currentFunctions);
 
         return result;
     }
 
+    //todo: manage defining project name when there are multiple namespaces - currently it will just use the first one it encounters, but this may not be ideal
     @Override
     public Map<String, ? extends CharSequence> afterAllGenerate(
             ResourceSet set,
@@ -182,6 +201,10 @@ public class PythonCodeGenerator extends AbstractExternalGenerator {
             result.putAll(generateInits(subfolders));
             result.putAll(processDAG(nameSpace, context, cleanVersion));
         }
+        String resolvedProjectName = (projectName != null && !projectName.isBlank())
+                ? projectName
+                : "python-" + contexts.keySet().stream().findFirst().map(ns -> ns.split("\\.")[0]).orElse("unknown");
+        result.put(PYPROJECT_TOML, PythonCodeGeneratorUtil.createToml(resolvedProjectName, cleanVersion));
         return result;
     }
 
@@ -196,7 +219,6 @@ public class PythonCodeGenerator extends AbstractExternalGenerator {
         Set<String> enumImports = context.getEnumImports();
 
         if (nameSpaceObjects != null && !nameSpaceObjects.isEmpty() && dependencyDAG != null && enumImports != null) {
-            result.put(PYPROJECT_TOML, PythonCodeGeneratorUtil.createPYProjectTomlFile(nameSpace, cleanVersion, projectName));
             PythonCodeWriter bundleWriter = new PythonCodeWriter();
             TopologicalOrderIterator<String, DefaultEdge> topologicalOrderIterator = new TopologicalOrderIterator<>(
                     dependencyDAG);

--- a/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGeneratorCLI.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGeneratorCLI.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
+import java.util.regex.Pattern;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
@@ -41,11 +42,13 @@ import org.eclipse.xtext.util.CancelIndicator;
  * </p>
  *
  * <h2>Usage</h2>
- * 
+ *
  * <pre>
  *   java -cp &lt;your-jar-or-classpath&gt; com.regnosys.rosetta.generator.python.PythonCodeGeneratorCLI -s &lt;source-dir&gt; -t &lt;target-dir&gt;
  *   java -cp &lt;your-jar-or-classpath&gt; com.regnosys.rosetta.generator.python.PythonCodeGeneratorCLI -f &lt;source-file&gt; -t &lt;target-dir&gt;
  * </pre>
+ *
+ * <h2>Options</h2>
  * <ul>
  * <li><b>-s, --dir &lt;source-dir&gt;</b>: Source directory containing Rosetta
  * files (all <code>.rosetta</code> files will be processed)</li>
@@ -53,13 +56,27 @@ import org.eclipse.xtext.util.CancelIndicator;
  * process</li>
  * <li><b>-t, --tgt &lt;target-dir&gt;</b>: Target directory for generated
  * Python code (defaults to <code>./python</code> if not specified)</li>
+ * <li><b>-p, --project-name &lt;projectName&gt;</b>: Override the
+ * <code>pyproject.toml</code> project name (default:
+ * <code>python-&lt;first-namespace-segment&gt;</code>)</li>
+ * <li><b>-x, --namespace-prefix &lt;prefix&gt;</b>: Prepend a prefix segment
+ * to every generated namespace (e.g. {@code finos} turns {@code cdm.x.y} into
+ * {@code finos.cdm.x.y})</li>
+ * <li><b>-v, --version &lt;version&gt;</b>: Version for the generated Python
+ * package, in <code>#.#.#</code> format (e.g. {@code 1.2.3}). Defaults to
+ * {@code 0.0.0} when omitted. An error is raised if the supplied value does not
+ * match the required format.</li>
+ * <li><b>-e, --allow-errors</b>: Continue generation even if Rosetta
+ * validation errors occur</li>
+ * <li><b>-w, --fail-on-warnings</b>: Treat Rosetta validation warnings as
+ * errors</li>
  * <li><b>-h</b>: Print usage/help</li>
  * </ul>
  *
  * <h2>Example</h2>
- * 
+ *
  * <pre>
- *   java -jar target/python-0.0.0.main-SNAPSHOT-shaded.jar -s src/main/rosetta -t build/python
+ *   java -jar target/python-0.0.0.main-SNAPSHOT-shaded.jar -s src/main/rosetta -t build/python -v 1.2.3 -p my-package
  * </pre>
  *
  * <h2>Notes</h2>
@@ -77,6 +94,8 @@ import org.eclipse.xtext.util.CancelIndicator;
 
 public class PythonCodeGeneratorCLI {
     private static final Logger LOGGER = LoggerFactory.getLogger(PythonCodeGeneratorCLI.class);
+    private static final Pattern VALID_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
+    static final String DEFAULT_VERSION = "0.0.0";
 
     public static void main(String[] args) {
         System.exit(new PythonCodeGeneratorCLI().execute(args));
@@ -96,8 +115,14 @@ public class PythonCodeGeneratorCLI {
                 .desc("Continue generation even if validation errors occur").build();
         Option failOnWarningsOpt = Option.builder("w").longOpt("fail-on-warnings")
                 .desc("Treat validation warnings as errors").build();
-        Option projectNameOpt = Option.builder("n").longOpt("project-name").argName("projectName")
+        Option projectNameOpt = Option.builder("p").longOpt("project-name").argName("projectName")
                 .desc("Override the pyproject.toml project name (default: python-<first-namespace-segment>)")
+                .hasArg().build();
+        Option namespacePrefixOpt = Option.builder("x").longOpt("namespace-prefix").argName("namespacePrefix")
+                .desc("Prepend a prefix segment to every namespace (e.g. 'finos' turns 'cdm.x.y' into 'finos.cdm.x.y')")
+                .hasArg().build();
+        Option versionOpt = Option.builder("v").longOpt("version").argName("version")
+                .desc("Specify the version for the generated Python code")
                 .hasArg().build();
 
         options.addOption(help);
@@ -107,6 +132,8 @@ public class PythonCodeGeneratorCLI {
         options.addOption(allowErrorsOpt);
         options.addOption(failOnWarningsOpt);
         options.addOption(projectNameOpt);
+        options.addOption(namespacePrefixOpt);
+        options.addOption(versionOpt);
 
         CommandLineParser parser = new DefaultParser();
         try {
@@ -118,14 +145,37 @@ public class PythonCodeGeneratorCLI {
             String tgtDir = cmd.getOptionValue("t", "./python");
             boolean allowErrors = cmd.hasOption("e");
             boolean failOnWarnings = cmd.hasOption("w");
-            String projectName = cmd.getOptionValue("n");
+            String projectName = cmd.getOptionValue("p");
+            String namespacePrefix = cmd.getOptionValue("x");
+            String versionInput = cmd.getOptionValue("v");
+
+            if (versionInput != null && !VALID_VERSION_PATTERN.matcher(versionInput).matches()) {
+                System.err.println("Invalid version format '" + versionInput + "': must be #.#.# (e.g. 1.2.3)");
+                return 1;
+            }
 
             if (cmd.hasOption("s")) {
                 String srcDir = cmd.getOptionValue("s");
-                return translateFromSourceDir(srcDir, tgtDir, allowErrors, failOnWarnings, projectName);
+                return translateFromSourceDir(
+                    srcDir, 
+                    tgtDir, 
+                    allowErrors, 
+                    failOnWarnings, 
+                    projectName,
+                    namespacePrefix,
+                    versionInput
+                );
             } else if (cmd.hasOption("f")) {
                 String srcFile = cmd.getOptionValue("f");
-                return translateFromSourceFile(srcFile, tgtDir, allowErrors, failOnWarnings, projectName);
+                return translateFromSourceFile(
+                    srcFile, 
+                    tgtDir, 
+                    allowErrors, 
+                    failOnWarnings, 
+                    projectName,
+                    namespacePrefix,
+                    versionInput
+                );
             } else {
                 System.err.println("Either a source directory (-s) or source file (-f) must be specified.");
                 printUsage(options);
@@ -143,12 +193,15 @@ public class PythonCodeGeneratorCLI {
         formatter.printHelp("PythonCodeGeneratorCLI", options, true);
     }
 
-    protected int translateFromSourceDir(String srcDir, String tgtDir, boolean allowErrors, boolean failOnWarnings) {
-        return translateFromSourceDir(srcDir, tgtDir, allowErrors, failOnWarnings, null);
-    }
-
-    protected int translateFromSourceDir(String srcDir, String tgtDir, boolean allowErrors, boolean failOnWarnings,
-            String projectName) {
+    protected int translateFromSourceDir(
+        String srcDir, 
+        String tgtDir, 
+        boolean allowErrors, 
+        boolean failOnWarnings,
+        String projectName, 
+        String namespacePrefix,
+        String versionInput
+    ) {
         Path srcDirPath = Paths.get(srcDir);
         if (!Files.exists(srcDirPath)) {
             LOGGER.error("Source directory does not exist: {}", srcDir);
@@ -163,19 +216,29 @@ public class PythonCodeGeneratorCLI {
                     .filter(Files::isRegularFile)
                     .filter(f -> f.getFileName().toString().endsWith(".rosetta"))
                     .collect(Collectors.toList());
-            return processRosettaFiles(rosettaFiles, tgtDir, allowErrors, failOnWarnings, projectName);
+            return processRosettaFiles(
+                rosettaFiles, 
+                tgtDir, 
+                allowErrors, 
+                failOnWarnings, 
+                projectName,
+                namespacePrefix,
+                versionInput);
         } catch (IOException e) {
             LOGGER.error("Failed to process source directory: {}", srcDir, e);
             return 1;
         }
     }
 
-    protected int translateFromSourceFile(String srcFile, String tgtDir, boolean allowErrors, boolean failOnWarnings) {
-        return translateFromSourceFile(srcFile, tgtDir, allowErrors, failOnWarnings, null);
-    }
-
-    protected int translateFromSourceFile(String srcFile, String tgtDir, boolean allowErrors, boolean failOnWarnings,
-            String projectName) {
+    protected int translateFromSourceFile(
+        String srcFile, 
+        String tgtDir, 
+        boolean allowErrors, 
+        boolean failOnWarnings,
+        String projectName, 
+        String namespacePrefix,
+        String versionInput
+    ) {
         Path srcFilePath = Paths.get(srcFile);
         if (!Files.exists(srcFilePath)) {
             LOGGER.error("Source file does not exist: {}", srcFile);
@@ -190,21 +253,30 @@ public class PythonCodeGeneratorCLI {
             return 1;
         }
         List<Path> rosettaFiles = List.of(srcFilePath);
-        return processRosettaFiles(rosettaFiles, tgtDir, allowErrors, failOnWarnings, projectName);
+        return processRosettaFiles(
+            rosettaFiles, 
+            tgtDir, 
+            allowErrors, 
+            failOnWarnings, 
+            projectName, 
+            namespacePrefix, 
+            versionInput
+        );
     }
 
     protected IResourceValidator getValidator(Injector injector) {
         return injector.getInstance(IResourceValidator.class);
     }
 
-    // Common processing function
-    protected int processRosettaFiles(List<Path> rosettaFiles, String tgtDir, boolean allowErrors,
-            boolean failOnWarnings) {
-        return processRosettaFiles(rosettaFiles, tgtDir, allowErrors, failOnWarnings, null);
-    }
-
-    protected int processRosettaFiles(List<Path> rosettaFiles, String tgtDir, boolean allowErrors,
-            boolean failOnWarnings, String projectName) {
+    protected int processRosettaFiles(
+        List<Path> rosettaFiles, 
+        String tgtDir, 
+        boolean allowErrors,
+        boolean failOnWarnings, 
+        String projectName, 
+        String namespacePrefix,
+        String versionInput
+    ) {
         LOGGER.info("Processing {} .rosetta files, writing to: {}", rosettaFiles.size(), tgtDir);
 
         if (rosettaFiles.isEmpty()) {
@@ -224,6 +296,7 @@ public class PythonCodeGeneratorCLI {
 
         PythonCodeGenerator pythonCodeGenerator = injector.getInstance(PythonCodeGenerator.class);
         pythonCodeGenerator.setProjectName(projectName);
+        pythonCodeGenerator.setNamespacePrefix(namespacePrefix);
         PythonModelLoader modelLoader = injector.getInstance(PythonModelLoader.class);
 
         List<RosettaModel> models = modelLoader.getRosettaModels(resources);
@@ -231,7 +304,7 @@ public class PythonCodeGeneratorCLI {
             LOGGER.error("No valid Rosetta models found.");
             return 1;
         }
-        String version = models.getFirst().getVersion();
+        String version = (versionInput != null) ? versionInput : DEFAULT_VERSION;
 
         LOGGER.info("Processing {} models, version: {}", models.size(), version);
 

--- a/src/main/java/com/regnosys/rosetta/generator/python/enums/PythonEnumGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/enums/PythonEnumGenerator.java
@@ -14,15 +14,17 @@ public class PythonEnumGenerator {
     /**
      * Generate Python from the collection of Rosetta enumerations.
      * 
-     * @param rosettaEnums the collection of Rosetta enumerations to generate
-     * @param version      the version for this collection of enumerations
+     * @param rosettaEnums    the collection of Rosetta enumerations to generate
+     * @param namespacePrefix optional prefix to prepend to the namespace
      * @return a Map of all the generated Python indexed by the file name
      */
-    public Map<String, String> generate(Iterable<RosettaEnumeration> rosettaEnums, String version) {
+    public Map<String, String> generate(Iterable<RosettaEnumeration> rosettaEnums, String namespacePrefix) {
         Map<String, String> result = new HashMap<>();
         for (RosettaEnumeration enumeration : rosettaEnums) {
             RosettaModel tr = (RosettaModel) enumeration.eContainer();
-            String namespace = tr.getName();
+            String namespace = (namespacePrefix != null && !namespacePrefix.isBlank())
+                    ? namespacePrefix + "." + tr.getName()
+                    : tr.getName();
 
             PythonCodeWriter writer = new PythonCodeWriter();
             writer.appendLine("# pylint: disable=missing-module-docstring, invalid-name, line-too-long");

--- a/src/main/java/com/regnosys/rosetta/generator/python/functions/PythonFunctionDependencyProvider.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/functions/PythonFunctionDependencyProvider.java
@@ -25,48 +25,52 @@ public class PythonFunctionDependencyProvider {
     private RObjectFactory rTypeBuilderFactory;
 
     public void addDependencies(EObject object, Set<String> enumImports) {
+        addDependencies(object, enumImports, null);
+    }
+
+    public void addDependencies(EObject object, Set<String> enumImports, String namespacePrefix) {
         if (object instanceof RosettaEnumeration enumeration) {
             String name = enumeration.getName();
             RosettaModel model = (RosettaModel) enumeration.eContainer();
-            String prefix = model.getName();
+            String prefix = applyPrefix(model.getName(), namespacePrefix);
             enumImports.add("import " + prefix + "." + name);
         } else if (object instanceof RosettaEnumValueReference ref) {
-            addDependencies(ref.getEnumeration(), enumImports);
+            addDependencies(ref.getEnumeration(), enumImports, namespacePrefix);
         } else if (object instanceof RosettaBinaryOperation binary) {
-            addDependencies(binary.getLeft(), enumImports);
-            addDependencies(binary.getRight(), enumImports);
+            addDependencies(binary.getLeft(), enumImports, namespacePrefix);
+            addDependencies(binary.getRight(), enumImports, namespacePrefix);
         } else if (object instanceof RosettaConditionalExpression cond) {
-            addDependencies(cond.getIf(), enumImports);
-            addDependencies(cond.getIfthen(), enumImports);
-            addDependencies(cond.getElsethen(), enumImports);
+            addDependencies(cond.getIf(), enumImports, namespacePrefix);
+            addDependencies(cond.getIfthen(), enumImports, namespacePrefix);
+            addDependencies(cond.getElsethen(), enumImports, namespacePrefix);
         } else if (object instanceof RosettaOnlyExistsExpression onlyExists) {
-            onlyExists.getArgs().forEach(arg -> addDependencies(arg, enumImports));
+            onlyExists.getArgs().forEach(arg -> addDependencies(arg, enumImports, namespacePrefix));
         } else if (object instanceof RosettaFunctionalOperation functional) {
             if (functional.getArgument() != null) {
-                addDependencies(functional.getArgument(), enumImports);
+                addDependencies(functional.getArgument(), enumImports, namespacePrefix);
             }
             if (functional instanceof FilterOperation filter) {
-                addDependencies(filter.getFunction(), enumImports);
+                addDependencies(filter.getFunction(), enumImports, namespacePrefix);
             } else if (functional instanceof MapOperation map) {
-                addDependencies(map.getFunction(), enumImports);
+                addDependencies(map.getFunction(), enumImports, namespacePrefix);
             }
         } else if (object instanceof RosettaUnaryOperation unary) {
-            addDependencies(unary.getArgument(), enumImports);
+            addDependencies(unary.getArgument(), enumImports, namespacePrefix);
         } else if (object instanceof RosettaFeatureCall featureCall) {
-            addDependencies(featureCall.getReceiver(), enumImports);
+            addDependencies(featureCall.getReceiver(), enumImports, namespacePrefix);
         } else if (object instanceof RosettaSymbolReference symbolRef) {
-            addDependencies(symbolRef.getSymbol(), enumImports);
-            symbolRef.getArgs().forEach(arg -> addDependencies(arg, enumImports));
+            addDependencies(symbolRef.getSymbol(), enumImports, namespacePrefix);
+            symbolRef.getArgs().forEach(arg -> addDependencies(arg, enumImports, namespacePrefix));
         } else if (object instanceof InlineFunction inline) {
-            addDependencies(inline.getBody(), enumImports);
+            addDependencies(inline.getBody(), enumImports, namespacePrefix);
         } else if (object instanceof ListLiteral listLiteral) {
-            listLiteral.getElements().forEach(el -> addDependencies(el, enumImports));
+            listLiteral.getElements().forEach(el -> addDependencies(el, enumImports, namespacePrefix));
         } else if (object instanceof RosettaConstructorExpression constructor) {
             if (constructor.getTypeCall() != null && constructor.getTypeCall().getType() != null) {
-                addDependencies(constructor.getTypeCall().getType(), enumImports);
+                addDependencies(constructor.getTypeCall().getType(), enumImports, namespacePrefix);
             }
             constructor.getValues()
-                    .forEach(valuePair -> addDependencies(valuePair.getValue(), enumImports));
+                    .forEach(valuePair -> addDependencies(valuePair.getValue(), enumImports, namespacePrefix));
         } else if (object instanceof Function ||
                 object instanceof Data ||
                 object instanceof RosettaExternalFunction ||
@@ -81,16 +85,26 @@ public class PythonFunctionDependencyProvider {
         } else if (object != null) {
             // Recurse into all children for unknown EObjects to ensure thorough dependency
             // collection
-            object.eContents().forEach(child -> addDependencies(child, enumImports));
+            object.eContents().forEach(child -> addDependencies(child, enumImports, namespacePrefix));
         }
     }
 
     public void addDependencies(RType type, Set<String> enumImports) {
+        addDependencies(type, enumImports, null);
+    }
+
+    public void addDependencies(RType type, Set<String> enumImports, String namespacePrefix) {
         if (type instanceof REnumType enumType) {
             String name = enumType.getName();
-            String prefix = enumType.getNamespace().toString();
+            String prefix = applyPrefix(enumType.getNamespace().toString(), namespacePrefix);
             enumImports.add("import " + prefix + "." + name);
         }
+    }
+
+    private static String applyPrefix(String name, String namespacePrefix) {
+        return (namespacePrefix != null && !namespacePrefix.isBlank())
+                ? namespacePrefix + "." + name
+                : name;
     }
 
     public Set<RFunction> rFunctionDependencies(RosettaExpression expression) {

--- a/src/main/java/com/regnosys/rosetta/generator/python/functions/PythonFunctionGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/functions/PythonFunctionGenerator.java
@@ -39,12 +39,11 @@ public class PythonFunctionGenerator {
      * Generate Python from the collection of Rosetta functions.
      * 
      * @param rFunctions the collection of Rosetta functions to generate
-     * @param version    the version for this collection of functions
      * @return a Map of all the generated Python indexed by the file name
      */
 
-    public Map<String, String> generate(Iterable<Function> rFunctions, String version,
-            PythonCodeGeneratorContext context) {
+    public Map<String, String> generate(Iterable<Function> rFunctions,
+            PythonCodeGeneratorContext context, String namespacePrefix) {
         Graph<String, DefaultEdge> dependencyDAG = context.getDependencyDAG();
         if (dependencyDAG == null) {
             throw new RuntimeException("Dependency DAG not initialized");
@@ -63,16 +62,15 @@ public class PythonFunctionGenerator {
                 LOGGER.warn("Function {} has no container, skipping", rf.getName());
                 continue;
             }
-            // String nameSpace = PythonCodeGeneratorUtil.getNamespace(model);
             try {
-                String pythonFunction = generateFunction(rf, version, enumImports);
+                String pythonFunction = generateFunction(rf, enumImports, namespacePrefix);
 
-                String functionName = RuneToPythonMapper.getFullyQualifiedObjectName(rf);
+                String functionName = RuneToPythonMapper.getFullyQualifiedObjectName(rf, namespacePrefix);
                 result.put(functionName, pythonFunction);
                 dependencyDAG.addVertex(functionName);
                 context.addFunctionName(functionName);
 
-                addFunctionDependencies(dependencyDAG, functionName, rf);
+                addFunctionDependencies(dependencyDAG, functionName, rf, namespacePrefix);
             } catch (Exception ex) {
                 LOGGER.error("Exception occurred generating rf {}", rf.getName(), ex);
                 throw new RuntimeException("Error generating Python for function " + rf.getName(), ex);
@@ -81,7 +79,8 @@ public class PythonFunctionGenerator {
         return result;
     }
 
-    private void addFunctionDependencies(Graph<String, DefaultEdge> dependencyDAG, String functionName, Function rf) {
+    private void addFunctionDependencies(Graph<String, DefaultEdge> dependencyDAG, String functionName, Function rf,
+            String namespacePrefix) {
         Set<RosettaNamed> dependencies = new HashSet<>();
 
         rf.getInputs().forEach(input -> {
@@ -112,17 +111,26 @@ public class PythonFunctionGenerator {
         for (RosettaNamed dep : dependencies) {
             String depName = "";
             if (dep instanceof Data) {
-                depName = rObjectFactory.buildRDataType((Data) dep).getQualifiedName().toString();
+                depName = applyPrefix(rObjectFactory.buildRDataType((Data) dep).getQualifiedName().toString(),
+                        namespacePrefix);
             } else if (dep instanceof Function) {
-                depName = RuneToPythonMapper.getFullyQualifiedObjectName((Function) dep);
+                depName = RuneToPythonMapper.getFullyQualifiedObjectName((Function) dep, namespacePrefix);
             } else if (dep instanceof RosettaEnumeration) {
-                depName = rObjectFactory.buildREnumType((RosettaEnumeration) dep).getQualifiedName().toString();
+                depName = applyPrefix(
+                        rObjectFactory.buildREnumType((RosettaEnumeration) dep).getQualifiedName().toString(),
+                        namespacePrefix);
             }
 
             if (!depName.isEmpty() && !functionName.equals(depName)) {
                 addDependency(dependencyDAG, functionName, depName);
             }
         }
+    }
+
+    private static String applyPrefix(String name, String namespacePrefix) {
+        return (namespacePrefix != null && !namespacePrefix.isBlank())
+                ? namespacePrefix + "." + name
+                : name;
     }
 
     private void addDependency(Graph<String, DefaultEdge> dependencyDAG, String className, String dependencyName) {
@@ -136,14 +144,14 @@ public class PythonFunctionGenerator {
         }
     }
 
-    private String generateFunction(Function rf, String version, Set<String> enumImports) {
+    private String generateFunction(Function rf, Set<String> enumImports, String namespacePrefix) {
         if (rf == null) {
             throw new RuntimeException("Function is null");
         }
         if (enumImports == null) {
             throw new RuntimeException("Enum imports is null");
         }
-        enumImports.addAll(collectFunctionDependencies(rf));
+        enumImports.addAll(collectFunctionDependencies(rf, namespacePrefix));
         PythonCodeWriter writer = new PythonCodeWriter();
 
         writer.appendLine("");
@@ -151,10 +159,11 @@ public class PythonFunctionGenerator {
 
         writer.appendLine("@replaceable");
         writer.appendLine("@validate_call");
-        writer.appendLine("def " + RuneToPythonMapper.getBundleObjectName(rf) + generateInputs(rf) + ":");
+        writer.appendLine("def " + RuneToPythonMapper.getBundleObjectName(rf, namespacePrefix)
+                + generateInputs(rf, namespacePrefix) + ":");
         writer.indent();
 
-        writer.appendBlock(generateDescription(rf));
+        writer.appendBlock(generateDescription(rf, namespacePrefix));
 
         if (!rf.getConditions().isEmpty()) {
             writer.appendLine("_pre_registry = {}");
@@ -172,7 +181,7 @@ public class PythonFunctionGenerator {
 
         int[] level = { 0 };
         generateAlias(writer, rf, level);
-        generateOperations(writer, rf, level);
+        generateOperations(writer, rf, level, namespacePrefix);
         generateOutput(writer, rf);
 
         writer.unindent();
@@ -181,12 +190,13 @@ public class PythonFunctionGenerator {
         return writer.toString();
     }
 
-    private String generateInputs(Function function) {
+    private String generateInputs(Function function, String namespacePrefix) {
         StringBuilder result = new StringBuilder("(");
         List<Attribute> inputs = function.getInputs();
         for (int i = 0; i < inputs.size(); i++) {
             Attribute input = inputs.get(i);
-            String inputBundleName = RuneToPythonMapper.getBundleObjectName(input.getTypeCall().getType());
+            String inputBundleName = RuneToPythonMapper.getBundleObjectName(input.getTypeCall().getType(),
+                    namespacePrefix);
             String inputType = RuneToPythonMapper.formatPythonType(
                     inputBundleName,
                     input.getCard().getInf(),
@@ -201,7 +211,8 @@ public class PythonFunctionGenerator {
         result.append(") -> ");
         Attribute output = function.getOutput();
         if (output != null) {
-            String outputBundleName = RuneToPythonMapper.getBundleObjectName(output.getTypeCall().getType());
+            String outputBundleName = RuneToPythonMapper.getBundleObjectName(output.getTypeCall().getType(),
+                    namespacePrefix);
             String outputType = RuneToPythonMapper.formatPythonType(
                     outputBundleName,
                     1, // Force min=1 to suppress Optional/| None for return types
@@ -234,7 +245,7 @@ public class PythonFunctionGenerator {
         }
     }
 
-    private String generateDescription(Function function) {
+    private String generateDescription(Function function, String namespacePrefix) {
         List<Attribute> inputs = function.getInputs();
         Attribute output = function.getOutput();
         String description = function.getDefinition();
@@ -249,7 +260,7 @@ public class PythonFunctionGenerator {
         writer.appendLine("----------");
         for (Attribute input : inputs) {
             String paramName = RuneToPythonMapper.formatPythonType(
-                    RuneToPythonMapper.getFullyQualifiedObjectName(input.getTypeCall().getType()),
+                    RuneToPythonMapper.getFullyQualifiedObjectName(input.getTypeCall().getType(), namespacePrefix),
                     1, // Force min=1 to match legacy docstring format (no Optional)
                     input.getCard().getSup(),
                     true);
@@ -263,7 +274,7 @@ public class PythonFunctionGenerator {
         writer.appendLine("-------");
         if (output != null) {
             String paramName = RuneToPythonMapper.formatPythonType(
-                    RuneToPythonMapper.getFullyQualifiedObjectName(output.getTypeCall().getType()),
+                    RuneToPythonMapper.getFullyQualifiedObjectName(output.getTypeCall().getType(), namespacePrefix),
                     1, // Force min=1 to match legacy docstring format (no Optional)
                     output.getCard().getSup(),
                     true);
@@ -277,27 +288,31 @@ public class PythonFunctionGenerator {
         return writer.toString();
     }
 
-    private Set<String> collectFunctionDependencies(Function rf) {
+    private Set<String> collectFunctionDependencies(Function rf, String namespacePrefix) {
         Set<String> enumImports = new HashSet<>();
         rf.getShortcuts().forEach(
-                shortcut -> functionDependencyProvider.addDependencies(shortcut.getExpression(), enumImports));
+                shortcut -> functionDependencyProvider.addDependencies(shortcut.getExpression(), enumImports,
+                        namespacePrefix));
         rf.getOperations().forEach(
-                operation -> functionDependencyProvider.addDependencies(operation.getExpression(), enumImports));
+                operation -> functionDependencyProvider.addDependencies(operation.getExpression(), enumImports,
+                        namespacePrefix));
 
         List<Condition> allConditions = new ArrayList<>(rf.getConditions());
         allConditions.addAll(rf.getPostConditions());
         allConditions.forEach(
-                condition -> functionDependencyProvider.addDependencies(condition.getExpression(), enumImports));
+                condition -> functionDependencyProvider.addDependencies(condition.getExpression(), enumImports,
+                        namespacePrefix));
 
         rf.getInputs().forEach(input -> {
             if (input.getTypeCall() != null && input.getTypeCall().getType() != null) {
-                functionDependencyProvider.addDependencies(input.getTypeCall().getType(), enumImports);
+                functionDependencyProvider.addDependencies(input.getTypeCall().getType(), enumImports, namespacePrefix);
             }
         });
 
         if (rf.getOutput() != null && rf.getOutput().getTypeCall() != null
                 && rf.getOutput().getTypeCall().getType() != null) {
-            functionDependencyProvider.addDependencies(rf.getOutput().getTypeCall().getType(), enumImports);
+            functionDependencyProvider.addDependencies(rf.getOutput().getTypeCall().getType(), enumImports,
+                    namespacePrefix);
         }
         return enumImports;
     }
@@ -345,7 +360,7 @@ public class PythonFunctionGenerator {
         }
     }
 
-    private void generateOperations(PythonCodeWriter writer, Function function, int[] level) {
+    private void generateOperations(PythonCodeWriter writer, Function function, int[] level, String namespacePrefix) {
         if (function.getOutput() != null) {
             List<String> setNames = new ArrayList<>();
             for (Operation operation : function.getOperations()) {
@@ -363,7 +378,7 @@ public class PythonFunctionGenerator {
                 if (operation.isAdd()) {
                     generateAddOperation(writer, root, operation, function, expression, setNames);
                 } else {
-                    generateSetOperation(writer, root, operation, function, expression, setNames);
+                    generateSetOperation(writer, root, operation, function, expression, setNames, namespacePrefix);
                 }
             }
         }
@@ -402,19 +417,20 @@ public class PythonFunctionGenerator {
     }
 
     private void generateSetOperation(PythonCodeWriter writer, AssignPathRoot root, Operation operation,
-            Function function, String expression, List<String> setNames) {
+            Function function, String expression, List<String> setNames, String namespacePrefix) {
         Attribute attributeRoot = (Attribute) root;
         String equalsSign = " = ";
         if (attributeRoot.getTypeCall().getType() instanceof RosettaEnumeration || operation.getPath() == null) {
             writer.appendLine(attributeRoot.getName() + equalsSign + expression);
         } else {
-            String bundleName = RuneToPythonMapper.getBundleObjectName(attributeRoot.getTypeCall().getType());
+            String bundleName = RuneToPythonMapper.getBundleObjectName(attributeRoot.getTypeCall().getType(),
+                    namespacePrefix);
             if (!setNames.contains(attributeRoot.getName())) {
                 setNames.add(attributeRoot.getName());
                 writer.appendLine(attributeRoot.getName() + equalsSign + "_get_rune_object('"
                         + bundleName + "', " +
                         getNextPathElementName(operation.getPath()) + ", "
-                        + buildObject(expression, operation.getPath()) + ")");
+                        + buildObject(expression, operation.getPath(), namespacePrefix) + ")");
             } else {
                 writer.appendLine(attributeRoot.getName() + equalsSign + "set_rune_attr(rune_resolve_attr(self, '"
                         + attributeRoot.getName()
@@ -442,21 +458,21 @@ public class PythonFunctionGenerator {
         return (path == null) ? null : "'" + path.getFeature().getName() + "'";
     }
 
-    private String buildObject(String expression, Segment path) {
+    private String buildObject(String expression, Segment path, String namespacePrefix) {
         if (path == null || path.getNext() == null) {
             return expression;
         }
 
         RosettaFeature feature = path.getFeature();
         if (feature instanceof RosettaTyped typed) {
-            String bundleName = RuneToPythonMapper.getBundleObjectName(typed.getTypeCall().getType());
+            String bundleName = RuneToPythonMapper.getBundleObjectName(typed.getTypeCall().getType(), namespacePrefix);
             Segment nextPath = path.getNext();
             return "_get_rune_object('"
                     + bundleName
                     + "', "
                     + getNextPathElementName(nextPath)
                     + ", "
-                    + buildObject(expression, nextPath)
+                    + buildObject(expression, nextPath, namespacePrefix)
                     + ")";
         }
         throw new IllegalArgumentException("Cannot build object for feature " + feature.getName() + " of type "

--- a/src/main/java/com/regnosys/rosetta/generator/python/object/PythonAttributeProcessor.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/object/PythonAttributeProcessor.java
@@ -24,6 +24,11 @@ public class PythonAttributeProcessor {
     private TypeSystem typeSystem;
 
     public String generateAllAttributes(Data rc, Map<String, List<String>> keyRefConstraints) {
+        return generateAllAttributes(rc, keyRefConstraints, null);
+    }
+
+    public String generateAllAttributes(Data rc, Map<String, List<String>> keyRefConstraints,
+            String namespacePrefix) {
         RDataType buildRDataType = rObjectFactory.buildRDataType(rc);
         Collection<RAttribute> allAttributes = buildRDataType.getOwnAttributes();
 
@@ -33,20 +38,20 @@ public class PythonAttributeProcessor {
 
         PythonCodeWriter writer = new PythonCodeWriter();
         for (RAttribute ra : allAttributes) {
-            generateAttribute(writer, rc, ra, keyRefConstraints);
+            generateAttribute(writer, rc, ra, keyRefConstraints, namespacePrefix);
         }
         return writer.toString();
     }
 
     private void generateAttribute(PythonCodeWriter writer, Data rc, RAttribute ra,
-            Map<String, List<String>> keyRefConstraints) {
+            Map<String, List<String>> keyRefConstraints, String namespacePrefix) {
         RType rt = ra.getRMetaAnnotatedType().getRType();
 
         if (rt instanceof RAliasType) {
             rt = typeSystem.stripFromTypeAliases(rt);
         }
 
-        String attrTypeName = RuneToPythonMapper.toPythonType(rt);
+        String attrTypeName = RuneToPythonMapper.toPythonType(rt, namespacePrefix);
         if (rt instanceof RNumberType numberType && numberType.isInteger() && !"int".equals(attrTypeName)) {
             attrTypeName = "int";
         }
@@ -263,13 +268,10 @@ public class PythonAttributeProcessor {
     }
 
     public void getImportsFromAttributes(Data rc, Set<String> enumImports) {
-        /**
-         * Get ENUM imports from attributes (all other dependencies are handled by the
-         * bundle)
-         * 
-         * @param rc
-         * @param enumImports
-         */
+        getImportsFromAttributes(rc, enumImports, null);
+    }
+
+    public void getImportsFromAttributes(Data rc, Set<String> enumImports, String namespacePrefix) {
         RDataType buildRDataType = rObjectFactory.buildRDataType(rc);
         Collection<RAttribute> allAttributes = buildRDataType.getOwnAttributes();
 
@@ -287,8 +289,11 @@ public class PythonAttributeProcessor {
                             "Attribute type is null for " + attr.getName() + " for class " + rc.getName());
                 }
 
-                if (rt instanceof REnumType) {
-                    enumImports.add("import " + ((REnumType) rt).getQualifiedName());
+                if (rt instanceof REnumType enumType) {
+                    String qualifiedName = (namespacePrefix != null && !namespacePrefix.isBlank())
+                            ? namespacePrefix + "." + enumType.getQualifiedName()
+                            : enumType.getQualifiedName().toString();
+                    enumImports.add("import " + qualifiedName);
                 }
             }
         }

--- a/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectGenerator.java
@@ -3,7 +3,6 @@ package com.regnosys.rosetta.generator.python.object;
 import com.regnosys.rosetta.generator.python.PythonCodeGeneratorContext;
 
 import com.regnosys.rosetta.generator.python.expressions.PythonExpressionGenerator;
-import com.regnosys.rosetta.generator.python.util.PythonCodeGeneratorUtil;
 import com.regnosys.rosetta.generator.python.util.RuneToPythonMapper;
 import com.regnosys.rosetta.generator.python.util.PythonCodeWriter;
 import com.regnosys.rosetta.rosetta.RosettaModel;
@@ -41,12 +40,12 @@ public class PythonModelObjectGenerator {
     /**
      * Generate Python from the collection of Rosetta classes (of type Data).
      * 
-     * @param rClasses the collection of Rosetta Classes for this model
-     * @param version  the version for this collection of classes
+     * @param rClasses        the collection of Rosetta Classes for this model
+     * @param namespacePrefix optional prefix to prepend to every namespace
      * @return a Map of all the generated Python indexed by the class name
      */
-    public Map<String, String> generate(Iterable<Data> rClasses, String version,
-            PythonCodeGeneratorContext context) {
+    public Map<String, String> generate(Iterable<Data> rClasses,
+            PythonCodeGeneratorContext context, String namespacePrefix) {
         Graph<String, DefaultEdge> dependencyDAG = context.getDependencyDAG();
         if (dependencyDAG == null) {
             throw new RuntimeException("Dependency DAG not initialized");
@@ -60,26 +59,27 @@ public class PythonModelObjectGenerator {
 
         for (Data rc : rClasses) {
             RosettaModel model = (RosettaModel) rc.eContainer();
-            String nameSpace = PythonCodeGeneratorUtil.getNamespace(model);
+            String effectiveModelName = applyPrefix(model.getName(), namespacePrefix);
 
             // Generate Python for the class
             try {
-                String pythonClass = generateClass(rc, nameSpace, version, enumImports);
+                String pythonClass = generateClass(rc, enumImports, namespacePrefix);
 
                 // construct the class name using "." as a delimiter
-                String className = model.getName() + "." + rc.getName();
+                String className = effectiveModelName + "." + rc.getName();
                 result.put(className, pythonClass);
 
                 dependencyDAG.addVertex(className);
                 if (rc.getSuperType() != null) {
                     Data superClass = rc.getSuperType();
                     RosettaModel superModel = (RosettaModel) superClass.eContainer();
-                    String superClassName = superModel.getName() + "." + superClass.getName();
+                    String superClassName = applyPrefix(superModel.getName(), namespacePrefix)
+                            + "." + superClass.getName();
 
                     addDependency(dependencyDAG, className, superClassName);
                 }
 
-                addAttributeDependencies(dependencyDAG, className, rc);
+                addAttributeDependencies(dependencyDAG, className, rc, namespacePrefix);
             } catch (Exception e) {
                 throw new RuntimeException("Error generating Python for class " + rc.getName(), e);
             }
@@ -87,22 +87,29 @@ public class PythonModelObjectGenerator {
         return result;
     }
 
-    private void addAttributeDependencies(Graph<String, DefaultEdge> dependencyDAG, String className, Data rc) {
+    private void addAttributeDependencies(Graph<String, DefaultEdge> dependencyDAG, String className, Data rc,
+            String namespacePrefix) {
         RDataType buildRDataType = rObjectFactory.buildRDataType(rc);
         for (RAttribute attr : buildRDataType.getOwnAttributes()) {
             RType rt = attr.getRMetaAnnotatedType().getRType();
             if (rt instanceof RDataType || rt instanceof REnumType) {
                 String dependencyName = "";
                 if (rt instanceof RDataType) {
-                    dependencyName = ((RDataType) rt).getQualifiedName().toString();
+                    dependencyName = applyPrefix(((RDataType) rt).getQualifiedName().toString(), namespacePrefix);
                 } else {
-                    dependencyName = ((REnumType) rt).getQualifiedName().toString();
+                    dependencyName = applyPrefix(((REnumType) rt).getQualifiedName().toString(), namespacePrefix);
                 }
                 if (!dependencyName.isEmpty() && !className.equals(dependencyName)) {
                     addDependency(dependencyDAG, className, dependencyName);
                 }
             }
         }
+    }
+
+    private static String applyPrefix(String name, String namespacePrefix) {
+        return (namespacePrefix != null && !namespacePrefix.isBlank())
+                ? namespacePrefix + "." + name
+                : name;
     }
 
     private void addDependency(Graph<String, DefaultEdge> dependencyDAG, String className, String dependencyName) {
@@ -116,7 +123,7 @@ public class PythonModelObjectGenerator {
         }
     }
 
-    private String generateClass(Data rc, String nameSpace, String version, Set<String> enumImports) {
+    private String generateClass(Data rc, Set<String> enumImports, String namespacePrefix) {
         if (rc == null) {
             throw new RuntimeException("Rosetta class not initialized");
         }
@@ -128,9 +135,9 @@ public class PythonModelObjectGenerator {
             throw new RuntimeException("Enum imports not initialized");
         }
 
-        pythonAttributeProcessor.getImportsFromAttributes(rc, enumImports);
+        pythonAttributeProcessor.getImportsFromAttributes(rc, enumImports, namespacePrefix);
 
-        return generateBody(rc);
+        return generateBody(rc, namespacePrefix);
     }
 
     private String getClassMetaDataString(Data rc) {
@@ -186,17 +193,18 @@ public class PythonModelObjectGenerator {
         return writer.toString();
     }
 
-    private String generateBody(Data rc) {
+    private String generateBody(Data rc, String namespacePrefix) {
         RDataType rosettaDataType = rObjectFactory.buildRDataType(rc);
         Map<String, List<String>> keyRefConstraints = new HashMap<>();
 
         PythonCodeWriter writer = new PythonCodeWriter();
 
         String superClassName = (rc.getSuperType() != null)
-                ? RuneToPythonMapper.getBundleObjectName(rc.getSuperType())
+                ? RuneToPythonMapper.getBundleObjectName(rc.getSuperType(), namespacePrefix)
                 : "BaseDataClass";
 
-        writer.appendLine("class " + RuneToPythonMapper.getBundleObjectName(rc) + "(" + superClassName + "):");
+        writer.appendLine("class " + RuneToPythonMapper.getBundleObjectName(rc, namespacePrefix)
+                + "(" + superClassName + "):");
         writer.indent();
 
         String metaData = getClassMetaDataString(rc);
@@ -212,9 +220,10 @@ public class PythonModelObjectGenerator {
             writer.appendLine("\"\"\"");
         }
 
+        // _FQRTN uses the unmodified Rune type identity (not prefixed) for serialization compatibility
         writer.appendLine("_FQRTN = '" + RuneToPythonMapper.getFullyQualifiedObjectName(rc) + "'");
 
-        writer.appendBlock(pythonAttributeProcessor.generateAllAttributes(rc, keyRefConstraints));
+        writer.appendBlock(pythonAttributeProcessor.generateAllAttributes(rc, keyRefConstraints, namespacePrefix));
 
         String constraints = keyRefConstraintsToString(keyRefConstraints);
         if (!constraints.isEmpty()) {

--- a/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
@@ -95,29 +95,22 @@ public class PythonCodeGeneratorUtil {
         return rm.getName().split("\\.")[0];
     }
 
-    public static String createPYProjectTomlFile(String namespace, String version) {
-        return createPYProjectTomlFile(namespace, version, null);
-    }
-
-    public static String createPYProjectTomlFile(String namespace, String version, String projectName) {
-        String name = (projectName != null && !projectName.isBlank())
-                ? projectName
-                : "python-" + namespace.split("\\.")[0];
+    public static String createToml(String projectName, String version) {
         return """
-                [build-system]
-                requires = ["setuptools>=62.0"]
-                build-backend = "setuptools.build_meta"
+            [build-system]
+            requires = ["setuptools>=62.0"]
+            build-backend = "setuptools.build_meta"
 
-                [project]
-                name = "%s"
-                version = "%s"
-                requires-python = ">= 3.11"
-                dependencies = [
-                   "pydantic>=2.10.3",
-                   "rune.runtime>=1.0.0,<2.0.0"
-                ]
-                [tool.setuptools.packages.find]
-                where = ["src"]""".formatted(name, version).stripIndent();
+            [project]
+            name = "%s"
+            version = "%s"
+            requires-python = ">= 3.11"
+            dependencies = [
+                "pydantic<3.0.0",
+                "rune.runtime>=1.0.0,<2.0.0"
+            ]
+            [tool.setuptools.packages.find]
+            where = ["src"]""".formatted(projectName, version).stripIndent();
     }
 
     public static String cleanVersion(String version) {

--- a/src/main/java/com/regnosys/rosetta/generator/python/util/RuneToPythonMapper.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/util/RuneToPythonMapper.java
@@ -147,6 +147,10 @@ public class RuneToPythonMapper {
     }
 
     public static String getFullyQualifiedObjectName(RosettaNamed rn) {
+        return getFullyQualifiedObjectName(rn, null);
+    }
+
+    public static String getFullyQualifiedObjectName(RosettaNamed rn, String namespacePrefix) {
         RosettaModel model = (RosettaModel) rn.eContainer();
         if (model == null) {
             throw new RuntimeException("Rosetta model not found for data " + rn.getName());
@@ -157,8 +161,9 @@ public class RuneToPythonMapper {
         }
         String typeName = toPythonBasicTypeInnerFunction(rn.getName());
         if (typeName == null) {
+            String effectiveModelName = applyPrefix(model.getName(), namespacePrefix);
             String function = (rn instanceof Function) ? ".functions" : "";
-            typeName = model.getName() + function + "." + rn.getName();
+            typeName = effectiveModelName + function + "." + rn.getName();
             if (rn instanceof RosettaEnumeration) {
                 typeName += "." + rn.getName();
             }
@@ -167,7 +172,11 @@ public class RuneToPythonMapper {
     }
 
     public static String getBundleObjectName(RosettaNamed rn, boolean useQuotes) {
-        String fullyQualifiedObjectName = getFullyQualifiedObjectName(rn);
+        return getBundleObjectName(rn, useQuotes, null);
+    }
+
+    public static String getBundleObjectName(RosettaNamed rn, boolean useQuotes, String namespacePrefix) {
+        String fullyQualifiedObjectName = getFullyQualifiedObjectName(rn, namespacePrefix);
         if (rn instanceof RosettaEnumeration || isRosettaBasicType(rn.getName())) {
             return fullyQualifiedObjectName;
         }
@@ -179,7 +188,17 @@ public class RuneToPythonMapper {
     }
 
     public static String getBundleObjectName(RosettaNamed rn) {
-        return getBundleObjectName(rn, false);
+        return getBundleObjectName(rn, false, null);
+    }
+
+    public static String getBundleObjectName(RosettaNamed rn, String namespacePrefix) {
+        return getBundleObjectName(rn, false, namespacePrefix);
+    }
+
+    private static String applyPrefix(String name, String namespacePrefix) {
+        return (namespacePrefix != null && !namespacePrefix.isBlank())
+                ? namespacePrefix + "." + name
+                : name;
     }
 
     /**
@@ -203,12 +222,17 @@ public class RuneToPythonMapper {
      * @return the Python type name string, or null if rt is null
      */
     public static String toPythonType(RType rt, boolean useQuotes) {
+        return toPythonType(rt, useQuotes, null);
+    }
+
+    public static String toPythonType(RType rt, boolean useQuotes, String namespacePrefix) {
         if (rt == null)
             return null;
         var pythonType = toPythonBasicTypeInnerFunction(rt.getName());
         if (pythonType == null) {
             String rtName = rt.getName();
-            pythonType = rt.getNamespace().toString() + "." + rtName;
+            String effectiveNamespace = applyPrefix(rt.getNamespace().toString(), namespacePrefix);
+            pythonType = effectiveNamespace + "." + rtName;
             pythonType = (rt instanceof REnumType) ? pythonType + "." + rtName : pythonType;
 
             if (!isRosettaBasicType(rt) && !(rt instanceof REnumType)) {
@@ -228,7 +252,11 @@ public class RuneToPythonMapper {
      * @return the Python type name string, or null if rt is null
      */
     public static String toPythonType(RType rt) {
-        return toPythonType(rt, false);
+        return toPythonType(rt, false, null);
+    }
+
+    public static String toPythonType(RType rt, String namespacePrefix) {
+        return toPythonType(rt, false, namespacePrefix);
     }
 
     /**

--- a/src/test/java/com/regnosys/rosetta/generator/python/PythonCodeGeneratorCLITest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/PythonCodeGeneratorCLITest.java
@@ -93,6 +93,67 @@ class PythonCodeGeneratorCLITest {
         assertEquals(1, exitCode, "Should return 1 (fail) when warnings occur and --fail-on-warnings is set");
     }
 
+    @Test
+    void testInvalidVersionFormatTooFewSegmentsReturnsError() {
+        PythonCodeGeneratorCLI cli = new PythonCodeGeneratorCLI();
+        int exitCode = cli.execute(new String[] { "-s", ".", "-v", "1.2" });
+        assertEquals(1, exitCode, "Should return 1 when version has fewer than three segments");
+    }
+
+    @Test
+    void testInvalidVersionFormatNonNumericReturnsError() {
+        PythonCodeGeneratorCLI cli = new PythonCodeGeneratorCLI();
+        int exitCode = cli.execute(new String[] { "-s", ".", "-v", "abc.def.ghi" });
+        assertEquals(1, exitCode, "Should return 1 when version segments are not numeric");
+    }
+
+    @Test
+    void testInvalidVersionFormatWithSnapshotSuffixReturnsError() {
+        PythonCodeGeneratorCLI cli = new PythonCodeGeneratorCLI();
+        int exitCode = cli.execute(new String[] { "-s", ".", "-v", "1.2.3-SNAPSHOT" });
+        assertEquals(1, exitCode, "Should return 1 when version has a non-numeric suffix");
+    }
+
+    @Test
+    void testValidVersionAppearsInToml() throws IOException {
+        Path validFile = createValidRosettaFile(tempDir);
+        Path outputDir = tempDir.resolve("python");
+        TestCLI cli = new TestCLI();
+
+        int exitCode = cli.execute(new String[] {
+                "-f", validFile.toString(),
+                "-t", outputDir.toString(),
+                "-v", "2.5.1"
+        });
+
+        assertEquals(0, exitCode, "Should return 0 when a valid version is provided");
+        Path toml = outputDir.resolve("pyproject.toml");
+        assertTrue(Files.exists(toml), "pyproject.toml should be written to the output directory");
+        String tomlContent = Files.readString(toml);
+        assertTrue(tomlContent.contains("version = \"2.5.1\""),
+                "pyproject.toml should contain the version specified via -v");
+    }
+
+    @Test
+    void testProjectNameOptionSetsTomlName() throws IOException {
+        Path validFile = createValidRosettaFile(tempDir);
+        Path outputDir = tempDir.resolve("python");
+        TestCLI cli = new TestCLI();
+
+        int exitCode = cli.execute(new String[] {
+                "-f", validFile.toString(),
+                "-t", outputDir.toString(),
+                "-p", "my-custom-project"
+        });
+
+        assertEquals(0, exitCode, "Should return 0 when -p option is provided");
+        Path toml = outputDir.resolve("pyproject.toml");
+        assertTrue(Files.exists(toml), "pyproject.toml should be written to the output directory");
+        String tomlContent = Files.readString(toml);
+        assertTrue(tomlContent.contains("name = \"my-custom-project\""),
+                "pyproject.toml should contain the project name specified via -p");
+    }
+
     private Path createValidRosettaFile(Path dir) throws IOException {
         Path file = dir.resolve("valid.rosetta");
         String content = "namespace test.model\nversion \"1.0.0\"\ntype Foo:\n    attr string (1..1)\n";

--- a/src/test/java/com/regnosys/rosetta/generator/python/PythonGeneratorTestUtils.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/PythonGeneratorTestUtils.java
@@ -29,19 +29,30 @@ public class PythonGeneratorTestUtils {
     }
 
     public Map<String, CharSequence> generatePythonFromString(String modelContent) {
-        // model.parseRosettaWithNoErrors in Xtend ->
-        // modelHelper.parseRosettaWithNoErrors(modelContent)
-        RosettaModel m = modelHelper.parseRosettaWithNoErrors(modelContent);
-        ResourceSet resourceSet = m.eResource().getResourceSet();
-        String version = m.getVersion();
+        return generatePythonFromString(modelContent, null);
+    }
 
-        Map<String, CharSequence> result = new HashMap<>();
-        result.putAll(generator.beforeAllGenerate(resourceSet, Collections.singletonList(m), version));
-        result.putAll(generator.beforeGenerate(m.eResource(), m, version));
-        result.putAll(generator.generate(m.eResource(), m, version));
-        result.putAll(generator.afterGenerate(m.eResource(), m, version));
-        result.putAll(generator.afterAllGenerate(resourceSet, Collections.singletonList(m), version));
-        return result;
+    public Map<String, CharSequence> generatePythonFromString(String modelContent, String namespacePrefix) {
+        return generatePythonFromString(modelContent, namespacePrefix, null);
+    }
+
+    public Map<String, CharSequence> generatePythonFromString(String modelContent, String namespacePrefix, String version) {
+        generator.setNamespacePrefix(namespacePrefix);
+        try {
+            RosettaModel m = modelHelper.parseRosettaWithNoErrors(modelContent);
+            ResourceSet resourceSet = m.eResource().getResourceSet();
+            String resolvedVersion = (version != null) ? version : m.getVersion();
+
+            Map<String, CharSequence> result = new HashMap<>();
+            result.putAll(generator.beforeAllGenerate(resourceSet, Collections.singletonList(m), resolvedVersion));
+            result.putAll(generator.beforeGenerate(m.eResource(), m, resolvedVersion));
+            result.putAll(generator.generate(m.eResource(), m, resolvedVersion));
+            result.putAll(generator.afterGenerate(m.eResource(), m, resolvedVersion));
+            result.putAll(generator.afterAllGenerate(resourceSet, Collections.singletonList(m), resolvedVersion));
+            return result;
+        } finally {
+            generator.setNamespacePrefix(null);
+        }
     }
 
     public String generatePythonAndExtractBundle(String model) {

--- a/src/test/java/com/regnosys/rosetta/generator/python/PythonTomlGeneratorTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/PythonTomlGeneratorTest.java
@@ -1,0 +1,110 @@
+package com.regnosys.rosetta.generator.python;
+
+import jakarta.inject.Inject;
+import com.regnosys.rosetta.tests.RosettaInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaInjectorProvider.class)
+public class PythonTomlGeneratorTest {
+
+    private static final String PYPROJECT_TOML = "pyproject.toml";
+
+    @Inject
+    private PythonGeneratorTestUtils testUtils;
+
+    @Test
+    public void testTomlFileIsGenerated() {
+        Map<String, CharSequence> generated = testUtils.generatePythonFromString(
+                """
+                type Foo:
+                    bar string (0..1)
+                """);
+
+        assertTrue(generated.containsKey(PYPROJECT_TOML),
+                "Expected pyproject.toml to be present in generated output");
+    }
+
+    @Test
+    public void testTomlContainsBuildSystem() {
+        String toml = generateToml();
+
+        assertTrue(toml.contains("[build-system]"), "Missing [build-system] section");
+        assertTrue(toml.contains("requires = [\"setuptools>=62.0\"]"), "Missing setuptools requirement");
+        assertTrue(toml.contains("build-backend = \"setuptools.build_meta\""), "Missing build-backend");
+    }
+
+    @Test
+    public void testTomlContainsProjectSection() {
+        String toml = generateToml();
+
+        assertTrue(toml.contains("[project]"), "Missing [project] section");
+        assertTrue(toml.contains("requires-python = \">= 3.11\""), "Missing requires-python");
+    }
+
+    @Test
+    public void testTomlProjectNameDerivedFromNamespace() {
+        // The default test namespace is com.rosetta.test.model, so the first segment is "com"
+        String toml = generateToml();
+
+        assertTrue(toml.contains("name = \"python-com\""),
+                "Expected project name 'python-com' derived from namespace 'com.rosetta.test.model'");
+    }
+
+    @Test
+    public void testTomlDefaultVersionIsZeroZeroZero() {
+        // When no version is supplied the generator receives the model's raw version
+        // string (${project.version} in tests), which cleanVersion() maps to 0.0.0.
+        // This mirrors the CLI default: if -v is omitted, DEFAULT_VERSION ("0.0.0") is used.
+        String toml = generateToml(null);
+
+        assertTrue(toml.contains("version = \"0.0.0\""),
+                "Expected default version '0.0.0' when no version is specified");
+    }
+
+    @Test
+    public void testTomlVersionWhenSpecified() {
+        String toml = generateToml("1.2.3");
+
+        assertTrue(toml.contains("version = \"1.2.3\""),
+                "Expected version '1.2.3' when explicitly specified");
+    }
+
+    @Test
+    public void testTomlContainsDependencies() {
+        String toml = generateToml();
+
+        assertTrue(toml.contains("\"pydantic<3.0.0\""), "Missing pydantic dependency");
+        assertTrue(toml.contains("\"rune.runtime>=1.0.0,<2.0.0\""), "Missing rune.runtime dependency");
+    }
+
+    @Test
+    public void testTomlContainsPackagesFindSection() {
+        String toml = generateToml();
+
+        assertTrue(toml.contains("[tool.setuptools.packages.find]"), "Missing [tool.setuptools.packages.find] section");
+        assertTrue(toml.contains("where = [\"src\"]"), "Missing where = [\"src\"] in packages.find");
+    }
+
+    private String generateToml() {
+        return generateToml(null);
+    }
+
+    private String generateToml(String version) {
+        Map<String, CharSequence> generated = testUtils.generatePythonFromString(
+                """
+                type Foo:
+                    bar string (0..1)
+                """, null, version);
+        CharSequence toml = generated.get(PYPROJECT_TOML);
+        assertNotNull(toml, "pyproject.toml was not generated");
+        return toml.toString();
+    }
+}

--- a/src/test/java/com/regnosys/rosetta/generator/python/generated_syntax/PythonNamespacePrefixTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/generated_syntax/PythonNamespacePrefixTest.java
@@ -1,0 +1,336 @@
+package com.regnosys.rosetta.generator.python.generated_syntax;
+
+import jakarta.inject.Inject;
+import com.regnosys.rosetta.tests.RosettaInjectorProvider;
+import com.regnosys.rosetta.generator.python.PythonGeneratorTestUtils;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that the -x / --namespace-prefix option correctly prepends a prefix
+ * segment to every namespace throughout all generated Python artefacts.
+ *
+ * <p>The model uses namespace {@code cdm.event.common} and prefix {@code finos},
+ * so the effective namespace becomes {@code finos.cdm.event.common}.
+ *
+ * <p>No-prefix behaviour is already thoroughly covered by
+ * {@link PythonBasicGeneratorTest} (namespace {@code test.generated_syntax.basic})
+ * and the other tests in the {@code generated_syntax} package.  This class also
+ * includes explicit no-prefix assertions for the same model to make the
+ * before/after contrast immediately visible.
+ */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaInjectorProvider.class)
+public class PythonNamespacePrefixTest {
+
+    @Inject
+    private PythonGeneratorTestUtils testUtils;
+
+    private static final String PREFIX = "finos";
+
+    /**
+     * Rosetta model with a type, a type that references it, and an enum —
+     * covering every category of generated artefact.
+     */
+    private static final String MODEL = """
+            namespace cdm.event.common
+
+            type BusinessEvent:
+                eventType EventTypeEnum (0..1)
+                tradeDate date (0..1)
+
+            type ContractDetails:
+                businessEvent BusinessEvent (0..1)
+
+            enum EventTypeEnum:
+                Exercise
+                Novation
+
+            func GetYear: <"Get the year.">
+                inputs:
+                    n number (1..1)
+                output:
+                    result number (1..1)
+                set result:
+                    n
+            """;
+
+    private Map<String, CharSequence> withPrefix() {
+        return testUtils.generatePythonFromString(MODEL, PREFIX);
+    }
+
+    private Map<String, CharSequence> withoutPrefix() {
+        return testUtils.generatePythonFromString(MODEL);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bundle file path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testBundleFilePathWithPrefix() {
+        assertTrue(withPrefix().containsKey("src/finos/_bundle.py"),
+                "Bundle should be at src/finos/_bundle.py when prefix is 'finos'");
+    }
+
+    @Test
+    void testBundleFilePathWithoutPrefix() {
+        Map<String, CharSequence> gen = withoutPrefix();
+        assertTrue(gen.containsKey("src/cdm/_bundle.py"),
+                "Bundle should be at src/cdm/_bundle.py when no prefix is set");
+        assertFalse(gen.containsKey("src/finos/_bundle.py"),
+                "src/finos/_bundle.py must not appear when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Enum standalone file path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testEnumFilePathWithPrefix() {
+        assertTrue(withPrefix().containsKey("src/finos/cdm/event/common/EventTypeEnum.py"),
+                "Enum file should be under src/finos/cdm/event/common/ when prefix is 'finos'");
+    }
+
+    @Test
+    void testEnumFilePathWithoutPrefix() {
+        Map<String, CharSequence> gen = withoutPrefix();
+        assertTrue(gen.containsKey("src/cdm/event/common/EventTypeEnum.py"),
+                "Enum file should be under src/cdm/event/common/ when no prefix is set");
+        assertFalse(gen.containsKey("src/finos/cdm/event/common/EventTypeEnum.py"),
+                "Prefixed enum path must not appear when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Type stub file path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testTypeStubFilePathWithPrefix() {
+        assertTrue(withPrefix().containsKey("src/finos/cdm/event/common/BusinessEvent.py"),
+                "Stub file should be at src/finos/cdm/event/common/BusinessEvent.py");
+    }
+
+    @Test
+    void testTypeStubFilePathWithoutPrefix() {
+        Map<String, CharSequence> gen = withoutPrefix();
+        assertTrue(gen.containsKey("src/cdm/event/common/BusinessEvent.py"),
+                "Stub file should be at src/cdm/event/common/BusinessEvent.py when no prefix");
+        assertFalse(gen.containsKey("src/finos/cdm/event/common/BusinessEvent.py"),
+                "Prefixed stub path must not appear when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Stub import statement  (standalone file → bundle)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testStubImportWithPrefix() {
+        String stub = withPrefix().get("src/finos/cdm/event/common/BusinessEvent.py").toString();
+        assertTrue(stub.contains("from finos._bundle import finos_cdm_event_common_BusinessEvent as BusinessEvent"),
+                "Stub must import from finos._bundle using the prefixed class name");
+    }
+
+    @Test
+    void testStubImportWithoutPrefix() {
+        String stub = withoutPrefix().get("src/cdm/event/common/BusinessEvent.py").toString();
+        assertTrue(stub.contains("from cdm._bundle import cdm_event_common_BusinessEvent as BusinessEvent"),
+                "Stub must import from cdm._bundle using the un-prefixed class name");
+        assertFalse(stub.contains("finos"),
+                "No prefix token must appear in the stub when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Bundle class name  (class definition line)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testBundleClassNameWithPrefix() {
+        String bundle = withPrefix().get("src/finos/_bundle.py").toString();
+        assertTrue(bundle.contains("class finos_cdm_event_common_BusinessEvent(BaseDataClass):"),
+                "Bundle class must use the prefixed name finos_cdm_event_common_BusinessEvent");
+    }
+
+    @Test
+    void testBundleClassNameWithoutPrefix() {
+        String bundle = withoutPrefix().get("src/cdm/_bundle.py").toString();
+        assertTrue(bundle.contains("class cdm_event_common_BusinessEvent(BaseDataClass):"),
+                "Bundle class must use cdm_event_common_BusinessEvent when no prefix");
+        assertFalse(bundle.contains("finos_"),
+                "No prefix token must appear in bundle class names when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // _FQRTN — must remain the unmodified Rune type identity in both cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFQRTNUnchangedWithPrefix() {
+        String bundle = withPrefix().get("src/finos/_bundle.py").toString();
+        assertTrue(bundle.contains("_FQRTN = 'cdm.event.common.BusinessEvent'"),
+                "_FQRTN must reflect the original Rune namespace, not the prefix");
+        assertFalse(bundle.contains("_FQRTN = 'finos.cdm"),
+                "_FQRTN must never include the namespace prefix");
+    }
+
+    @Test
+    void testFQRTNUnchangedWithoutPrefix() {
+        String bundle = withoutPrefix().get("src/cdm/_bundle.py").toString();
+        assertTrue(bundle.contains("_FQRTN = 'cdm.event.common.BusinessEvent'"),
+                "_FQRTN must be the Rune qualified name when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-type reference in bundle  (ContractDetails.businessEvent attribute)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testTypeReferenceInBundleWithPrefix() {
+        String bundle = withPrefix().get("src/finos/_bundle.py").toString();
+        assertTrue(bundle.contains("finos_cdm_event_common_BusinessEvent"),
+                "Attribute type reference in ContractDetails must use the prefixed class name");
+    }
+
+    @Test
+    void testTypeReferenceInBundleWithoutPrefix() {
+        String bundle = withoutPrefix().get("src/cdm/_bundle.py").toString();
+        assertTrue(bundle.contains("cdm_event_common_BusinessEvent"),
+                "Attribute type reference must use un-prefixed class name when no prefix");
+        assertFalse(bundle.contains("finos_cdm"),
+                "No prefixed type references must appear when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Enum import in bundle header
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testEnumImportInBundleWithPrefix() {
+        String bundle = withPrefix().get("src/finos/_bundle.py").toString();
+        assertTrue(bundle.contains("import finos.cdm.event.common.EventTypeEnum"),
+                "Enum import in bundle must be prefixed with 'finos.'");
+    }
+
+    @Test
+    void testEnumImportInBundleWithoutPrefix() {
+        String bundle = withoutPrefix().get("src/cdm/_bundle.py").toString();
+        assertTrue(bundle.contains("import cdm.event.common.EventTypeEnum"),
+                "Enum import must use the un-prefixed namespace when no prefix is set");
+        assertFalse(bundle.contains("import finos."),
+                "No prefixed enum import must appear when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // __init__.py files  (workspace and sub-package layers)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testInitFilesWithPrefix() {
+        Map<String, CharSequence> gen = withPrefix();
+        assertTrue(gen.containsKey("src/finos/__init__.py"),
+                "Top-level __init__.py must be created under src/finos/");
+        assertTrue(gen.containsKey("src/finos/cdm/__init__.py"),
+                "__init__.py must be created for the cdm sub-package");
+        assertTrue(gen.containsKey("src/finos/cdm/event/__init__.py"),
+                "__init__.py must be created for the cdm.event sub-package");
+        assertTrue(gen.containsKey("src/finos/cdm/event/common/__init__.py"),
+                "__init__.py must be created for the cdm.event.common sub-package");
+    }
+
+    @Test
+    void testInitFilesWithoutPrefix() {
+        Map<String, CharSequence> gen = withoutPrefix();
+        assertTrue(gen.containsKey("src/cdm/__init__.py"),
+                "Top-level __init__.py must be at src/cdm/ when no prefix");
+        assertTrue(gen.containsKey("src/cdm/event/__init__.py"),
+                "__init__.py must be created for the cdm.event sub-package when no prefix");
+        assertTrue(gen.containsKey("src/cdm/event/common/__init__.py"),
+                "__init__.py must be created for cdm.event.common when no prefix");
+        assertFalse(gen.containsKey("src/finos/__init__.py"),
+                "src/finos/__init__.py must not be created when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Function stub file path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFunctionStubFilePathWithPrefix() {
+        assertTrue(withPrefix().containsKey("src/finos/cdm/event/common/functions/GetYear.py"),
+                "Function stub must be at src/finos/cdm/event/common/functions/GetYear.py when prefix is 'finos'");
+    }
+
+    @Test
+    void testFunctionStubFilePathWithoutPrefix() {
+        Map<String, CharSequence> gen = withoutPrefix();
+        assertTrue(gen.containsKey("src/cdm/event/common/functions/GetYear.py"),
+                "Function stub must be at src/cdm/event/common/functions/GetYear.py when no prefix");
+        assertFalse(gen.containsKey("src/finos/cdm/event/common/functions/GetYear.py"),
+                "Prefixed function stub path must not appear when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Function stub import statement
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFunctionStubImportWithPrefix() {
+        String stub = withPrefix().get("src/finos/cdm/event/common/functions/GetYear.py").toString();
+        assertTrue(stub.contains("from finos._bundle import finos_cdm_event_common_functions_GetYear as GetYear"),
+                "Function stub must import from finos._bundle using the prefixed function name");
+    }
+
+    @Test
+    void testFunctionStubImportWithoutPrefix() {
+        String stub = withoutPrefix().get("src/cdm/event/common/functions/GetYear.py").toString();
+        assertTrue(stub.contains("from cdm._bundle import cdm_event_common_functions_GetYear as GetYear"),
+                "Function stub must import from cdm._bundle using the un-prefixed function name");
+        assertFalse(stub.contains("finos"),
+                "No prefix token must appear in the function stub when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // Bundle function def name
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testBundleFunctionDefWithPrefix() {
+        String bundle = withPrefix().get("src/finos/_bundle.py").toString();
+        assertTrue(bundle.contains("def finos_cdm_event_common_functions_GetYear("),
+                "Bundle must define function as finos_cdm_event_common_functions_GetYear when prefix is 'finos'");
+    }
+
+    @Test
+    void testBundleFunctionDefWithoutPrefix() {
+        String bundle = withoutPrefix().get("src/cdm/_bundle.py").toString();
+        assertTrue(bundle.contains("def cdm_event_common_functions_GetYear("),
+                "Bundle must define function as cdm_event_common_functions_GetYear when no prefix");
+        assertFalse(bundle.contains("def finos_"),
+                "No prefixed function def must appear in bundle when no prefix is set");
+    }
+
+    // -------------------------------------------------------------------------
+    // functions/__init__.py
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFunctionInitFileWithPrefix() {
+        assertTrue(withPrefix().containsKey("src/finos/cdm/event/common/functions/__init__.py"),
+                "__init__.py must be created for the functions sub-package under src/finos/cdm/event/common/");
+    }
+
+    @Test
+    void testFunctionInitFileWithoutPrefix() {
+        Map<String, CharSequence> gen = withoutPrefix();
+        assertTrue(gen.containsKey("src/cdm/event/common/functions/__init__.py"),
+                "__init__.py must be created for the functions sub-package under src/cdm/event/common/");
+        assertFalse(gen.containsKey("src/finos/cdm/event/common/functions/__init__.py"),
+                "Prefixed functions __init__.py must not appear when no prefix is set");
+    }
+}

--- a/test/cdm_tests/cdm_setup/build_cdm.sh
+++ b/test/cdm_tests/cdm_setup/build_cdm.sh
@@ -46,7 +46,7 @@ CDM_SOURCE_PATH="$MY_PATH/../rosetta"
 PYTHON_TARGET_PATH=$PROJECT_ROOT_PATH/target/python-cdm
 PYTHON_SETUP_PATH="$MY_PATH/../../python_setup"
 JAR_PATH="$PROJECT_ROOT_PATH/target/python-0.0.0.main-SNAPSHOT.jar"
-CDM_PACKAGE_PREFIX="finos_cdm"
+CDM_PROJECT_NAME="finos_cdm"
 cd ${MY_PATH} || error
 
 # Parse command-line arguments for --skip-cdm
@@ -77,7 +77,7 @@ if [[ ! -f "$JAR_PATH" ]]; then
 fi
 
 echo "***** build CDM"
-java -cp "$JAR_PATH" com.regnosys.rosetta.generator.python.PythonCodeGeneratorCLI -s $CDM_SOURCE_PATH -t $PYTHON_TARGET_PATH -n $CDM_PACKAGE_PREFIX || error "Failed to generate CDM Python code"
+java -cp "$JAR_PATH" com.regnosys.rosetta.generator.python.PythonCodeGeneratorCLI -s $CDM_SOURCE_PATH -t $PYTHON_TARGET_PATH -p $CDM_PROJECT_NAME || error "Failed to generate CDM Python code"
 JAVA_EXIT_CODE=$?
 if [[ $JAVA_EXIT_CODE -eq 1 ]]; then
     echo "Java program returned exit code 1. Stopping script."
@@ -94,7 +94,7 @@ source "$PROJECT_ROOT_PATH/$VENV_NAME/${PY_SCRIPTS}/activate" || error
 
 echo "***** build CDM Python package"
 cd $PYTHON_TARGET_PATH
-rm $CDM_PACKAGE_PREFIX-*.*.*-py3-none-any.whl
+rm $CDM_PROJECT_NAME-*.*.*-py3-none-any.whl
 python -m pip wheel --no-deps --only-binary :all: . || processError
 
 echo "***** cleanup"

--- a/test/python_unit_tests/run_python_unit_tests.sh
+++ b/test/python_unit_tests/run_python_unit_tests.sh
@@ -103,6 +103,8 @@ MY_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "${MY_PATH}" || error
 PROJECT_ROOT_PATH="$MY_PATH/../.."
 PYTHON_SETUP_PATH="$MY_PATH/../python_setup"
+PROJECT_NAME="python_rosetta_dsl"
+PROJECT_VERSION="0.0.0"
 
 JAR_PATH="$PROJECT_ROOT_PATH/target/python-0.0.0.main-SNAPSHOT.jar"
 
@@ -141,7 +143,9 @@ echo "***** generating Python for unit tests"
 mkdir -p "$PYTHON_TESTS_TARGET_PATH"
 java -cp "$JAR_PATH" com.regnosys.rosetta.generator.python.PythonCodeGeneratorCLI \
   -s "$INPUT_ROSETTA_PATH" \
-  -t "$PYTHON_TESTS_TARGET_PATH"
+  -t "$PYTHON_TESTS_TARGET_PATH" \
+  -p "$PROJECT_NAME" \
+  -v "$PROJECT_VERSION"
 JAVA_EXIT_CODE=$?
 if [[ $JAVA_EXIT_CODE -ne 0 ]]; then
   echo "Java program returned exit code $JAVA_EXIT_CODE. Stopping script."
@@ -157,7 +161,7 @@ if [[ $REUSE_ENV -eq 1 && -d "$VENV_PATH" ]]; then
   # shellcheck disable=SC1090
   source "$VENV_PATH/${PY_SCRIPTS}/activate" || error
   echo "***** removing existing python_rosetta_dsl package"
-  python -m pip uninstall -y python_rosetta_dsl || true
+  python -m pip uninstall -y $PROJECT_NAME || true
 else
   echo "***** setting up common environment"
   # shellcheck disable=SC1090
@@ -171,7 +175,7 @@ fi
 # package and install generated Python
 cd "$PYTHON_TESTS_TARGET_PATH" || error
 python -m pip wheel --no-deps --only-binary :all: . || error
-python -m pip install python_rosetta_dsl-0.0.0-py3-none-any.whl
+python -m pip install $PROJECT_NAME-$PROJECT_VERSION-py3-none-any.whl
 
 # run tests
 echo "***** run unit tests"


### PR DESCRIPTION
## Summary

This PR adds two features to the Python code generator:

1. **Namespace prefix** — a new `-x` CLI option prepends a user-supplied segment to every generated namespace (e.g. turning `cdm.event.common` into `finos.cdm.event.common`) thereby creating packages that avoid potential name-clashes with existing Python package 
  See Issue [#181 Top Level Package Name Collision Prevention](https://github.com/finos/rune-python-generator/issues/181)

2. **Explicit version control** — a new `-v` CLI option allows callers to specify the generated package version directly, with strict `#.#.#` format validation. The default `0.0.0` is now owned by the CLI rather than buried inside `cleanVersion()`.  This facilitates alignment with the version of input Rune collections.
 See Issue [#182 Specify The Version](https://github.com/finos/rune-python-generator/issues/182)

A number of smaller fixes and refactors accompany these features: a renamed CLI option (`-n` → `-p`), an updated pydantic version constraint, a refactored TOML helper, and comprehensive new test coverage.