### PR TITLE
fix: support cdm dev versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <repoServerHost>s01.oss.sonatype.org</repoServerHost>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rosetta.dsl.version>9.78.0</rosetta.dsl.version>
+        <rosetta.dsl.version>9.77.1</rosetta.dsl.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>

--- a/python-test/cdm-tests/setup/build_cdm.sh
+++ b/python-test/cdm-tests/setup/build_cdm.sh
@@ -53,7 +53,7 @@ PYTHON_SETUP_PATH="$MY_PATH/../../env-setup"
 JAR_PATH="$PROJECT_ROOT_PATH/target/python-0.0.0.main-SNAPSHOT.jar"
 CDM_PROJECT_NAME="finos-cdm"
 CDM_PREFIX="finos"
-CDM_VERSION="1.2.3"
+CDM_VERSION="7.0.0-dev.98"
 cd ${MY_PATH} || error
 
 

--- a/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
@@ -122,10 +122,13 @@ public static String fileComment(String version) {
     }
 
     public static String createVersionFile(String version) {
-        String versionComma = version.replace('.', ',');
+        String numericBase = version.contains(".dev")
+                ? version.substring(0, version.indexOf(".dev"))
+                : version;
+        String versionTuple = numericBase.replace('.', ',');
         return "version = ("
-                + versionComma + ",0)\n"
-                + "version_str = '" + version + "-0'\n"
+                + versionTuple + ")\n"
+                + "version_str = '" + version + "'\n"
                 + "__version__ = '" + version + "'\n"
                 + "__build_time__ = '"
                 + LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "'";

--- a/src/test/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtilTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtilTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.regnosys.rosetta.generator.python.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PythonCodeGeneratorUtilTest {
+
+    @Test
+    void testCreateVersionFileStableVersion() {
+        String result = PythonCodeGeneratorUtil.createVersionFile("7.0.0");
+        assertTrue(result.contains("version = (7,0,0)"), "version tuple should contain only numeric parts");
+        assertTrue(result.contains("version_str = '7.0.0'"), "version_str should match stable version");
+        assertTrue(result.contains("__version__ = '7.0.0'"), "__version__ should match stable version");
+    }
+
+    @Test
+    void testCreateVersionFileDevVersion() {
+        String result = PythonCodeGeneratorUtil.createVersionFile("7.0.0.dev98");
+        assertTrue(result.contains("version = (7,0,0)"), "version tuple should contain only numeric base, not dev suffix");
+        assertTrue(result.contains("version_str = '7.0.0.dev98'"), "version_str should include dev designation");
+        assertTrue(result.contains("__version__ = '7.0.0.dev98'"), "__version__ should be PEP 440 dev version");
+        assertFalse(result.contains("dev98,"), "dev suffix must not appear unquoted in the version tuple");
+    }
+
+    @Test
+    void testCreateVersionFileDevVersionTupleIsValidPython() {
+        String result = PythonCodeGeneratorUtil.createVersionFile("7.0.0.dev98");
+        // Ensure the tuple line contains only digits and commas (no bare identifiers)
+        String tupleLine = result.lines()
+                .filter(l -> l.startsWith("version = ("))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No version tuple line found"));
+        String tupleContent = tupleLine.replaceAll("version = \\((.*)\\)", "$1");
+        assertTrue(tupleContent.matches("[\\d,]+"), "version tuple must contain only digits and commas, got: " + tupleContent);
+    }
+
+    @Test
+    void testCleanVersionDevFormat() {
+        // CLI converts "7.0.0-dev.98" to "7.0.0.dev98" before calling cleanVersion
+        assertTrue(PythonCodeGeneratorUtil.cleanVersion("7.0.0.dev98").equals("7.0.0.dev98"),
+                "cleanVersion should preserve PEP 440 dev versions unchanged");
+    }
+
+    @Test
+    void testCleanVersionStable() {
+        assertTrue(PythonCodeGeneratorUtil.cleanVersion("7.0.0").equals("7.0.0"),
+                "cleanVersion should preserve stable versions unchanged");
+    }
+
+    @Test
+    void testCleanVersionNullReturnsDefault() {
+        assertTrue(PythonCodeGeneratorUtil.cleanVersion(null).equals("0.0.0"),
+                "cleanVersion should return 0.0.0 for null input");
+    }
+
+    @Test
+    void testCleanVersionMavenPlaceholderReturnsDefault() {
+        assertTrue(PythonCodeGeneratorUtil.cleanVersion("${project.version}").equals("0.0.0"),
+                "cleanVersion should return 0.0.0 for Maven placeholder");
+    }
+}


### PR DESCRIPTION
Generate a version file for CDM development versioning - (a.b.c-dev.d)

The version file will be:

version = (a,b,c)
version_str = 'a.b.c.devd'
__version__ = 'a.b.c.devd'
__build_time__ = '...'