### PR TITLE
Feat: Native Python FpML CodeList Validation and Resource Distribution (Resolves DSL I-150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ __pycache__
 **/test_helper-0.0.0-py3-none-any.whl
 **/python-test/serialization-tests/rune-common
 **/python-test/cdm-tests/rosetta/
+**/python-test/cdm-tests/resources/
 src/generated/
 *.todo
 /build/

--- a/python-test/cdm-tests/setup/build_cdm.sh
+++ b/python-test/cdm-tests/setup/build_cdm.sh
@@ -60,8 +60,8 @@ cd ${MY_PATH} || error
 source "$MY_PATH/../../ensure_jar_exists.sh" || { echo "Failed to source ensure_jar_exists.sh"; exit 1; }
 
 # Parse command-line arguments
-# CDM_BRANCH="master"
-CDM_BRANCH="6.x.x"
+CDM_BRANCH="master"
+# CDM_BRANCH="6.x.x"
 SKIP_CDM=0
 for arg in "$@"; do
   case "$arg" in
@@ -94,6 +94,36 @@ if [[ $JAVA_EXIT_CODE -eq 1 ]]; then
     echo "Java program returned exit code 1. Stopping script."
     exit 1
 fi
+
+echo "***** Injecting resources into the CDM package"
+
+# Define the resources source and the destination for the resources inside the CDM package
+RESOURCES_SRC="$MY_PATH/../resources/common-domain-model"
+RESOURCES_DEST="$PYTHON_TARGET_PATH/src/finos/resources"
+
+# Copy the files over
+mkdir -p "$RESOURCES_DEST"
+cp -r "$RESOURCES_SRC/"* "$RESOURCES_DEST/"
+
+# Create a MANIFEST.in file to force pip wheel to include the JSON files
+# NOTE: Because target/python-cdm is a volatile, auto-generated 
+# directory controlled by the Java generator, a static MANIFEST.in placed here 
+# would not be tracked by Git and could be destroyed.
+# Therefore, we dynamically inject this packaging rule during the build pipeline.
+echo "recursive-include src/finos/resources *" > "$PYTHON_TARGET_PATH/MANIFEST.in"
+
+echo "Resources injection successful!"
+
+echo "***** Injecting Python runtime extensions into the CDM package"
+
+EXTENSIONS_SRC="$MY_PATH/../../../src/main/python/runtime-extensions"
+EXTENSIONS_DEST="$PYTHON_TARGET_PATH/src/finos/runtime_extensions"
+
+# Copy the files over
+mkdir -p "$EXTENSIONS_DEST"
+cp -r "$EXTENSIONS_SRC/"* "$EXTENSIONS_DEST/"
+
+echo "Runtime extensions injection successful!"
 
 echo "***** build CDM Python package"
 cd $PYTHON_TARGET_PATH

--- a/python-test/cdm-tests/setup/get_cdm.sh
+++ b/python-test/cdm-tests/setup/get_cdm.sh
@@ -26,14 +26,19 @@ MY_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${MY_PATH} || error "Could not change to script directory"
 
 ROSETTA_DIR="${MY_PATH}/../rosetta"
+RESOURCES_DIR="${MY_PATH}/../resources"
 
 echo "***** resetting the rosetta directory"
 rm -rf "${ROSETTA_DIR}"
 mkdir -p "${ROSETTA_DIR}/common-domain-model"
 
+echo "***** resetting the resources directory"
+rm -rf "${RESOURCES_DIR}"
+mkdir -p "${RESOURCES_DIR}/common-domain-model"
+
 CDM_BRANCH=${1:-"master"}
 
-echo "***** pull CDM rosetta definitions ($CDM_BRANCH)"
+echo "***** pull CDM rosetta definitions and resources from Github ($CDM_BRANCH)"
 TEMP_CDM="${MY_PATH}/../temp_cdm"
 rm -rf "${TEMP_CDM}"
 mkdir -p "${TEMP_CDM}"
@@ -41,8 +46,10 @@ cd "${TEMP_CDM}"
 
 git init
 git config core.sparseCheckout true
+
 cat <<EOF > .git/info/sparse-checkout
 rosetta-source/src/main/rosetta/*
+rosetta-source/src/main/resources/codelist/json/*
 pom.xml
 rosetta-source/pom.xml
 EOF
@@ -52,6 +59,10 @@ git pull --depth 1 origin $CDM_BRANCH || error "git pull for CDM failed"
 
 # Copy CDM files to the target 'common-domain-model' folder
 cp -r rosetta-source/src/main/rosetta/* "${ROSETTA_DIR}/common-domain-model/"
+
+# Copy CDM resources to the target 'common-domain-model/resources' folder
+mkdir -p "${RESOURCES_DIR}/common-domain-model/codelist/json"
+cp -r rosetta-source/src/main/resources/codelist/json/* "${RESOURCES_DIR}/common-domain-model/codelist/json/"
 
 # Check for rune-fpml[-.]version property in pom.xml
 FPML_VERSION=$(sed -n 's/.*<rune-fpml[-.]version>\(.*\)<\/rune-fpml[-.]version>.*/\1/p' pom.xml | head -n 1)

--- a/python-test/cdm-tests/test_codelist_validation.py
+++ b/python-test/cdm-tests/test_codelist_validation.py
@@ -1,0 +1,26 @@
+import pytest
+
+# Import IoC container bootstrap script from CDM package
+from finos.runtime_extensions.cdm_runtime import setup_cdm_runtime
+
+# Import the official CDM facade for coding scheme validation
+import finos.cdm.base.staticdata.codelist.functions.ValidateFpMLCodingSchemeDomain as cdm_api
+
+# Initialize the IoC container for the entire test session
+@pytest.fixture(autouse=True, scope="session")
+def initialize_runtime():
+    setup_cdm_runtime()
+
+# Run the tests
+def test_valid_business_center_code():
+    is_valid = cdm_api.ValidateFpMLCodingSchemeDomain("GBLO", "business-center")
+    assert is_valid is True
+
+def test_invalid_business_center_code():
+    is_valid = cdm_api.ValidateFpMLCodingSchemeDomain("DUMMY_CODE", "business-center")
+    assert is_valid is False
+
+def test_missing_domain_raises_error():
+    with pytest.raises(FileNotFoundError):
+        cdm_api.ValidateFpMLCodingSchemeDomain("GBLO", "unknown-domain")
+

--- a/src/main/python/runtime-extensions/cdm/base/staticdata/codelist/load_codelist.py
+++ b/src/main/python/runtime-extensions/cdm/base/staticdata/codelist/load_codelist.py
@@ -1,0 +1,67 @@
+import json
+import logging
+import re
+from functools import lru_cache
+from importlib import resources as resource_loader
+from typing import cast
+
+# Codelist object for deserialization 
+from finos.cdm.base.staticdata.codelist.CodeList import CodeList
+
+# Configure logging
+logging.basicConfig (
+    level=logging.WARNING,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Dynamically locate the 'finos' CDM package in the environment. Then navigate to the nested resources folder
+codelist_dir = resource_loader.files("finos").joinpath("resources", "codelist", "json")
+
+# Add the LRU Cache. 
+# maxsize=15 means it will remember the last 128 requested domains in memory, evicting the least recently used (lcu) ones when the limit is exceeded.
+@lru_cache(maxsize=15)
+def load_codelist(domain: str) -> CodeList:
+    """
+    Loads a JSON CodeList based on domain and deserializes it into a CDM CodeList.
+    Results are cached to prevent redundant disk I/O and deserialization overhead.
+    """
+    # If you see this log, it means the cache was empty for this domain (Cache Miss).
+    # If you call the function again with the same domain, it skips the whole function 
+    # and returns the memory object instantly (Cache Hit), printing nothing.
+    logger.debug(f"Cache miss: Loading CodeList for domain '{domain}' from disk.")
+    
+    target_file = None
+
+    # Dynamically builds a pattern looking exactly for "domain-X-Y.json"
+    pattern = re.compile(rf"^{re.escape(domain.lower())}-\d+-\d+\.json$")
+    
+    # Search for the JSON file inside the wheel
+    for file_path in codelist_dir.iterdir():
+        if file_path.name.endswith(".json") and pattern.match(file_path.name):
+            target_file = file_path
+            break
+            
+    # If no file matching, log an error and raise an exception
+    if not target_file:
+        logger.error(f"Domain '{domain}' not found in {codelist_dir}")
+        raise FileNotFoundError(f"Could not find CodeList JSON for domain: '{domain}'")
+        
+    # Open and load the JSON directly from the package
+    try:
+        with target_file.open('r', encoding='utf-8') as f:
+            json_raw_data = json.load(f)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse JSON in {target_file.name}: {e}")
+        raise 
+        
+    # Use the inherited Rune deserialization method
+    try:
+        cdm_object = CodeList.rune_deserialize(json_raw_data)
+        logger.debug(f"Successfully deserialized CodeList for '{domain}'.")
+        return cast(CodeList, cdm_object)
+    except Exception as e:
+        logger.error(f"Rune deserialization failed for '{domain}': {e}")
+        raise

--- a/src/main/python/runtime-extensions/cdm_runtime.py
+++ b/src/main/python/runtime-extensions/cdm_runtime.py
@@ -1,0 +1,27 @@
+import logging
+
+# Import custom implementations
+from finos.runtime_extensions.cdm.base.staticdata.codelist.load_codelist import load_codelist as impl_load_codelist
+
+# Import the generated CDM facades (proxies)
+import finos.cdm.base.staticdata.codelist.functions.LoadCodeList as cdm_load_codelist_facade 
+
+logger = logging.getLogger(__name__)
+
+def setup_cdm_runtime():
+    """
+    Python equivalent of CdmRuntimeModule.java.
+    Wires custom native implementations into the auto-generated CDM Facades.
+    """
+    logger.info("Initializing CDM Python Runtime...")
+
+    # Inject LoadCodeList
+    if hasattr(cdm_load_codelist_facade, "LoadCodeList"):
+        cdm_load_codelist_facade.LoadCodeList.__assign__(impl_load_codelist) # type: ignore
+        logger.debug("Successfully bound LoadCodeList.")
+    else:
+        logger.error("Bootstrap Failed: Could not find LoadCodeList in CDM Facade.")
+
+    # Future injections (like RoundToNearest) will go here
+
+    logger.info("Succesfully initialized CDM Python Runtime!!!")


### PR DESCRIPTION
Hi @dschwartznyc , @plamen-neykov,

Following up on your request in [CDM I-3904](https://github.com/finos/common-domain-model/issues/3904) to consolidate our approach, our team decided to contribute our internal sandbox implementation directly to the test suite to establish a scalable pattern for FpML CodeList validation in Python.

## 1. What This PR Solves

This PR provides a complete, end-to-end solution for Issue [DSL I-150](https://github.com/finos/rune-python-generator/issues/150) by enabling FpML code list validation natively in Python for in-memory objects. It achieves this by:

- **Establishing a clean extension directory**: Creating src/main/python/runtime_extensions to house custom native Python implementations.
- **Native Bundling**: Bundling the required JSON codelist resources and the Python runtime extensions directly into the generated finos-cdm wheel artifact.
- **Custom Data Loader**: Providing a loader (load_codelist.py) that uses importlib and @lru_cache to efficiently read and deserialize those JSON files at runtime.
- **Runtime Initialization**: Introducing a Python runtime initializer (cdm_runtime.py) that acts similarly to Java's [CdmRuntimeModule](https://github.com/finos/common-domain-model/blob/master/rosetta-source/src/main/java/org/finos/cdm/CdmRuntimeModule.java). This seamlessly injects our custom loader into the natively generated LoadCodeList API using the __assign__ binding mechanism.

## 2. How to Validate This Implementation

While a standard mvn clean install will build the Java generator, it does not execute the Python-specific test suite. To test this implementation locally and execute test_codelist_validation.py, you must use the Python test runner scripts.

### Step 1: Clean Stale Artifacts (Important)
To ensure the script uses the latest compiled Java generator rather than a cached version, delete any existing snapshot JAR first:

```bash
rm target/python-0.0.0.main-SNAPSHOT.jar
```

### Step 2: Initial Build & Test
Run the CDM test script and use the -k flag to keep the virtual environment alive after the tests finish. (The script will automatically rebuild the Java JAR via maven, generate the Python code, bundle the JSONs and runtime extensions, and install the wheel into a fresh .pyenv).

```bash
./python-test/cdm-tests/run_cdm_tests.sh -k
```

### Step 3: Fast Iteration (Direct Pytest Execution)
Once the initial build from Step 2 completes, you do not need to use the bash scripts again. For fast test execution, simply activate the virtual environment and run pytest directly:

```bash
# Unix / Bash
source .pyenv/bin/activate
python -m pytest python-test/cdm-tests/test_codelist_validation.py

# Windows / Powershell
. .\.pyenv\bin\Activate.ps1 
python -m pytest python-test\cdm-tests\test_codelist_validation.py
```

## 3. Architecture & Data Flow Reference

Below is the consolidated data flow requested in [CDM I-3904](https://github.com/finos/common-domain-model/issues/3904) to provide a comprehensive view of how this implementation works without modifying the core generator logic:

- **CDM Python Build Process & Distribution**: We modified get_cdm.sh to pull rosetta-source/src/main/resources/codelist/json/* via sparse checkout. We then modified build_cdm.sh to copy these JSON files into src/finos/resources and copy the Python extensions into src/finos/runtime_extensions. Finally, we dynamically inject a MANIFEST.in configuration. This instructs the pip wheel builder to package these assets natively inside the .whl artifact.

- **Data Loading & Runtime Integration**: Our custom loader (load_codelist.py) utilizes Python's importlib.resources to locate the JSON files inside the installed package. It uses a regex match on the requested domain parameter to find the correct file, reads the payload, and deserializes it using CodeList.rune_deserialize. To prevent redundant disk I/O, it is wrapped in an @lru_cache.

- **Generator & Validation Flow**: We did not need to make any changes to the rune-python-generator. Because the logic for ValidateFpMLCodingSchemeDomain is now natively generated, our bootstrap script (finos.runtime_extensions.cdm_runtime) simply binds our loader to the LoadCodeList proxy API. The natively generated validation function executes flawlessly behind the scenes.

- **CDM's Serialization Format**: Our current contribution is strictly focused on enabling runtime data validation for in-memory objects. Consequently, we have not explored modifications to the CDM serialization format to append external list version references when saving documents. We consider this outside the scope of this initial runtime-loading implementation.