### PR TITLE
fix: enable use of a choice in a condition

### DIFF
--- a/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.java
@@ -306,6 +306,16 @@ public final class PythonExpressionGenerator {
             case WithMetaOperation withMeta -> {
                 return generateWithMetaOperation(withMeta, scope);
             }
+            case ChoiceOperation choice -> {
+                String receiver = choice.getArgument() != null
+                        ? generateExpression(choice.getArgument(), scope)
+                        : scope.receiver();
+                String attrs = choice.getAttributes().stream()
+                        .map(a -> "'" + a.getName() + "'")
+                        .collect(Collectors.joining(", "));
+                String necessity = choice.getNecessity() == Necessity.OPTIONAL ? "necessity=False" : "necessity=True";
+                return "rune_check_one_of(" + receiver + ", " + attrs + ", " + necessity + ")";
+            }
             default -> throw new UnsupportedOperationException(
                     "Unsupported expression type of " + expr.getClass().getSimpleName());
         }
@@ -398,10 +408,10 @@ public final class PythonExpressionGenerator {
                 String attrs = dt.getAllAttributes().stream()
                         .map(a -> "'" + a.getName() + "'")
                         .collect(Collectors.joining(", "));
-                return "rune_check_one_of(" + argument + ", " + attrs + ")";
+                return "rune_check_one_of(" + argument + ", " + attrs + ", necessity=True)";
             }
         }
-        return "rune_check_one_of(" + argument + ")";
+        return "rune_check_one_of(" + argument + ", necessity=True)";
     }
 
     private String generateFilterOperation(FilterOperation expr, PythonExpressionScope scope) {
@@ -653,19 +663,9 @@ public final class PythonExpressionGenerator {
     }
 
     private String generateConstraintCondition(Data cls, Condition cond) {
-        RosettaExpression expression = cond.getExpression();
-        List<Attribute> attributes = cls.getAttributes();
-        String necessity = "necessity=True";
-        if (expression instanceof ChoiceOperation choice) {
-            attributes = choice.getAttributes();
-            if (choice.getNecessity() == Necessity.OPTIONAL) {
-                necessity = "necessity=False";
-            }
-        }
-        String attrs = attributes.stream().map(a -> "'" + a.getName() + "'").collect(Collectors.joining(", "));
         PythonCodeWriter writer = new PythonCodeWriter();
         writer.indent();
-        writer.appendLine("return rune_check_one_of(self, " + attrs + ", " + necessity + ")");
+        writer.appendLine("return " + generateExpression(cond.getExpression(), PythonExpressionScope.of("self")));
         return writer.toString();
     }
 

--- a/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonConditionalExpressionTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonConditionalExpressionTest.java
@@ -254,33 +254,33 @@ public class PythonConditionalExpressionTest {
     public void testGenerateChoiceCondition() {
         testUtils.assertBundleContainsExpectedString("""
                 type Test1:<"Test choice condition.">
-                field1 string (0..1) <"Test string field 1">
-                field2 string (0..1) <"Test string field 2">
-                field3 string (0..1) <"Test string field 3">
-                condition TestChoice: optional choice field1, field2, field3
+                    field1 string (0..1) <"Test string field 1">
+                    field2 string (0..1) <"Test string field 2">
+                    field3 string (0..1) <"Test string field 3">
+                    condition TestChoice: optional choice field1, field2, field3
                 """,
                 """
-                        class Test1(BaseDataClass):
-                            \"""
-                            Test choice condition.
-                            \"""
-                            field1: Optional[str] = Field(None, description='Test string field 1')
-                            \"""
-                            Test string field 1
-                            \"""
-                            field2: Optional[str] = Field(None, description='Test string field 2')
-                            \"""
-                            Test string field 2
-                            \"""
-                            field3: Optional[str] = Field(None, description='Test string field 3')
-                            \"""
-                            Test string field 3
-                            \"""
+                class Test1(BaseDataClass):
+                    \"""
+                    Test choice condition.
+                    \"""
+                    field1: Optional[str] = Field(None, description='Test string field 1')
+                    \"""
+                    Test string field 1
+                    \"""
+                    field2: Optional[str] = Field(None, description='Test string field 2')
+                    \"""
+                    Test string field 2
+                    \"""
+                    field3: Optional[str] = Field(None, description='Test string field 3')
+                    \"""
+                    Test string field 3
+                    \"""
 
-                            @rune_condition
-                            def condition_0_TestChoice(self):
-                                item = self
-                                return rune_check_one_of(self, 'field1', 'field2', 'field3', necessity=False)""");
+                    @rune_condition
+                    def condition_0_TestChoice(self):
+                        item = self
+                        return rune_check_one_of(item, 'field1', 'field2', 'field3', necessity=False)""");
     }
 
     /**
@@ -294,19 +294,19 @@ public class PythonConditionalExpressionTest {
                     condition OneOf: one-of
                 """,
                 """
-                        class Test1(BaseDataClass):
-                            _CHOICE_ALIAS_MAP ={"field1":[]}
-                            \"""
-                            Test one-of condition.
-                            \"""
-                            field1: Optional[str] = Field(None, description='Test string field 1')
-                            \"""
-                            Test string field 1
-                            \"""
+                class Test1(BaseDataClass):
+                    _CHOICE_ALIAS_MAP ={"field1":[]}
+                    \"""
+                    Test one-of condition.
+                    \"""
+                    field1: Optional[str] = Field(None, description='Test string field 1')
+                    \"""
+                    Test string field 1
+                    \"""
 
-                            @rune_condition
-                            def condition_0_OneOf(self):
-                                item = self
-                                return rune_check_one_of(self, 'field1', necessity=True)""");
+                    @rune_condition
+                    def condition_0_OneOf(self):
+                        item = self
+                        return rune_check_one_of(item, 'field1', necessity=True)""");
     }
 }

--- a/src/test/java/com/regnosys/rosetta/generator/python/object/PythonConditionTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/object/PythonConditionTest.java
@@ -433,7 +433,7 @@ public class PythonConditionTest {
                         Test choice description.
                         \"""
                         item = self
-                        return rune_check_one_of(self, 'testTypeValue1', 'testTypeValue2', necessity=False)
+                        return rune_check_one_of(item, 'testTypeValue1', 'testTypeValue2', necessity=False)
                 """);
     }
 
@@ -500,7 +500,7 @@ public class PythonConditionTest {
                     @rune_condition
                     def condition_0_(self):
                         item = self
-                        return rune_check_one_of(self, 'a0', 'a1', necessity=True)
+                        return rune_check_one_of(item, 'a0', 'a1', necessity=True)
                 """);
         testUtils.assertGeneratedContainsExpectedString(
                 pythonString,
@@ -521,7 +521,7 @@ public class PythonConditionTest {
                         Choice rule to represent an FpML choice construct.
                         \"""
                         item = self
-                        return rune_check_one_of(self, 'intValue1', 'intValue2', necessity=False)
+                        return rune_check_one_of(item, 'intValue1', 'intValue2', necessity=False)
 
                     @rune_condition
                     def condition_2_ReqOneOrTwo(self):
@@ -529,7 +529,7 @@ public class PythonConditionTest {
                         Choice rule to represent an FpML choice construct.
                         \"""
                         item = self
-                        return rune_check_one_of(self, 'intValue1', 'intValue2', necessity=True)
+                        return rune_check_one_of(item, 'intValue1', 'intValue2', necessity=True)
 
                     @rune_condition
                     def condition_3_SecondOneOrTwo(self):
@@ -626,8 +626,34 @@ public class PythonConditionTest {
                 @rune_condition
                 def condition_0_Choice(self):
                     item = self
-                    return rune_check_one_of(self, 'intType', 'stringType', necessity=True)
+                    return rune_check_one_of(item, 'intType', 'stringType', necessity=True)
             """;
         testUtils.assertGeneratedContainsExpectedString(choicePython, expectedChoice);
+    }
+
+    /**
+     * Test case for a choice condition embedded in a compound expression.
+     * e.g. `if x is absent and required choice a, b, c then y exists`
+     * ChoiceOperation must be handled by generateExpression, not only by
+     * generateConstraintCondition (which only handles top-level choice).
+     */
+    @Test
+    public void testChoiceEmbeddedInCompoundCondition() {
+        Map<String, CharSequence> python = testUtils.generatePythonFromString(
+                """
+                type Foo:
+                    a int (0..1)
+                    b int (0..1)
+                    c int (0..1)
+                    d int (0..1)
+
+                    condition EmbeddedChoice:
+                        if a is absent
+                            and required choice b, c
+                        then d exists
+                """);
+        String generatedPython = python.get("src/com/rosetta/test/model/Foo.py").toString();
+        testUtils.assertGeneratedContainsExpectedString(generatedPython,
+                "rune_check_one_of(item, 'b', 'c', necessity=True)");
     }
 }

--- a/src/test/java/com/regnosys/rosetta/generator/python/object/PythonEnumTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/object/PythonEnumTest.java
@@ -105,7 +105,7 @@ public class PythonEnumTest {
                 @rune_condition
                 def condition_0_(self):
                     item = self
-                    return rune_check_one_of(self, 'ancillaryParty', 'legalEntity', necessity=True)
+                    return rune_check_one_of(item, 'ancillaryParty', 'legalEntity', necessity=True)
             """;
 
         String expectedTestType4 = """
@@ -192,7 +192,7 @@ public class PythonEnumTest {
                     Requires that a unit type must be set.
                     \"""
                     item = self
-                    return rune_check_one_of(self, 'capacityUnit', 'weatherUnit', necessity=True)
+                    return rune_check_one_of(item, 'capacityUnit', 'weatherUnit', necessity=True)
             """;
         String expectedTestType3 = """
             class WeatherUnitEnum(rune.runtime.metadata.EnumWithMetaMixin, Enum):

--- a/src/test/java/com/regnosys/rosetta/generator/python/object/PythonInheritanceTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/object/PythonInheritanceTest.java
@@ -322,7 +322,7 @@ public class PythonInheritanceTest {
                 @rune_condition
                 def condition_0_UnitType(self):
                     item = self
-                    return rune_check_one_of(self, 'capacityUnit', 'weatherUnit', 'financialUnit', 'currency', necessity=True)
+                    return rune_check_one_of(item, 'capacityUnit', 'weatherUnit', 'financialUnit', 'currency', necessity=True)
             """);
     }
 }


### PR DESCRIPTION
correctly process Rune syntax where choice is included in a condition.

for example:

```
type TestType: <"Test type description.">
    testTypeValue1 string (0..1) <"Test string">
    testTypeValue2 string (0..1) <"Test optional string">

    condition TestChoice: <"Test choice description.">
        optional choice testTypeValue1, testTypeValue2
```
