### PR TITLE
fix: make version string validation and processing consistent

### DIFF
--- a/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGeneratorCLI.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGeneratorCLI.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.cli.CommandLine;
@@ -120,14 +119,6 @@ public class PythonCodeGeneratorCLI {
      */
     static final String DEFAULT_VERSION = "0.0.0";
 
-    /**
-     * Regex that a version string must fully match: three dot-separated integers.
-     */
-    private static final Pattern VALID_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
-    /** Regex matching a dev version string such as {@code 1.2.3-dev.4}. */
-    private static final Pattern DEV_VERSION_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+)-dev\\.(\\d+)");
-    /** Regex matching a Maven SNAPSHOT version with branch qualifier such as {@code 0.0.0.featuremaster-Python-Update-SNAPSHOT}. */
-    private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+)\\.[A-Za-z][A-Za-z0-9_-]+-SNAPSHOT");
 
     /**
      * Public constructor for the CLI tool.
@@ -199,18 +190,11 @@ public class PythonCodeGeneratorCLI {
             String version = DEFAULT_VERSION;
             if (cmd.hasOption("v")) {
                 String rawVersion = cmd.getOptionValue("v");
-                java.util.regex.Matcher devMatcher = DEV_VERSION_PATTERN.matcher(rawVersion);
-                java.util.regex.Matcher snapshotMatcher = SNAPSHOT_VERSION_PATTERN.matcher(rawVersion);
-                if (snapshotMatcher.matches()) {
-                    version = snapshotMatcher.group(1) + ".dev0";
-                } else if (devMatcher.matches()) {
-                    version = devMatcher.group(1) + ".dev" + devMatcher.group(2);
-                } else if (VALID_VERSION_PATTERN.matcher(rawVersion).matches()) {
-                    version = rawVersion;
-                } else {
+                if (!PythonCodeGeneratorUtil.isValidVersion(rawVersion)) {
                     LOGGER.error("Invalid version format '{}'. Expected #.#.# (e.g. 1.2.3), #.#.#-dev.# (e.g. 1.2.3-dev.4), or #.#.#.<branch>-SNAPSHOT (e.g. 0.0.0.featuremaster-Python-Update-SNAPSHOT).", rawVersion);
                     return 1;
                 }
+                version = PythonCodeGeneratorUtil.cleanVersion(rawVersion);
             }
 
             if (projectName == null || projectName.isBlank()) {

--- a/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
@@ -6,13 +6,29 @@ package com.regnosys.rosetta.generator.python.util;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.regnosys.rosetta.rosetta.RosettaModel;
 import com.regnosys.rosetta.types.RAttribute;
 
 public final class PythonCodeGeneratorUtil {
 
+    public static final Pattern VALID_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
+    public static final Pattern DEV_VERSION_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+)-dev\\.(\\d+)");
+    public static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+)\\.[A-Za-z][A-Za-z0-9_-]+-SNAPSHOT");
+    private static final Pattern PEP440_DEV_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.dev\\d+");
+
     private PythonCodeGeneratorUtil() {
+    }
+
+    public static boolean isValidVersion(String version) {
+        if (version == null) {
+            return false;
+        }
+        return VALID_VERSION_PATTERN.matcher(version).matches()
+            || DEV_VERSION_PATTERN.matcher(version).matches()
+            || SNAPSHOT_VERSION_PATTERN.matcher(version).matches();
     }
 
     public static String fileComment(String version) {
@@ -184,24 +200,20 @@ public final class PythonCodeGeneratorUtil {
         if (version == null || version.equals("${project.version}")) {
             return "0.0.0";
         }
-
-        // Preserve PEP 440 dev versions already converted by the CLI (e.g. "1.2.3.dev4")
-        if (version.matches("\\d+\\.\\d+\\.\\d+\\.dev\\d+")) {
+        if (PEP440_DEV_VERSION_PATTERN.matcher(version).matches()) {
             return version;
         }
-
-        // Convert Maven SNAPSHOT versions with branch qualifier (e.g. "0.0.0.featuremaster-Python-Update-SNAPSHOT")
-        if (version.matches("\\d+\\.\\d+\\.\\d+\\.[A-Za-z][A-Za-z0-9-]+-SNAPSHOT")) {
-            String[] parts = version.split("\\.");
-            return parts[0] + "." + parts[1] + "." + parts[2] + ".dev0";
+        Matcher snapshotMatcher = SNAPSHOT_VERSION_PATTERN.matcher(version);
+        if (snapshotMatcher.matches()) {
+            return snapshotMatcher.group(1) + ".dev0";
         }
-
-        String[] versionParts = version.split("\\.");
-        if (versionParts.length > 2) {
-            String thirdPart = versionParts[2].replaceAll("[^\\d]", "");
-            return versionParts[0] + "." + versionParts[1] + "." + thirdPart;
+        Matcher devMatcher = DEV_VERSION_PATTERN.matcher(version);
+        if (devMatcher.matches()) {
+            return devMatcher.group(1) + ".dev" + devMatcher.group(2);
         }
-
+        if (VALID_VERSION_PATTERN.matcher(version).matches()) {
+            return version;
+        }
         return "0.0.0";
     }
     public static String mapMetaTypeToMetaDataName(String metaTypeName) {

--- a/src/test/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtilTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtilTest.java
@@ -6,6 +6,7 @@ package com.regnosys.rosetta.generator.python.util;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,5 +70,76 @@ class PythonCodeGeneratorUtilTest {
     void testCleanVersionSnapshotFormat() {
         assertTrue(PythonCodeGeneratorUtil.cleanVersion("0.0.0.featuremaster-Python-Update-SNAPSHOT").equals("0.0.0.dev0"),
                 "cleanVersion should convert Maven SNAPSHOT branch version to PEP 440 dev0");
+    }
+
+    @Test
+    void testCleanVersionSnapshotWithUnderscoreInBranch() {
+        assertEquals("0.0.0.dev0",
+                PythonCodeGeneratorUtil.cleanVersion("0.0.0.aanta_677ea5142b8d666852cae77-4784-CDM6-ProposedWorkflowStepFix_UpdExp-SNAPSHOT"),
+                "cleanVersion should handle SNAPSHOT branch qualifiers containing underscores");
+    }
+
+    @Test
+    void testCleanVersionMavenDevFormat() {
+        assertEquals("1.2.3.dev4",
+                PythonCodeGeneratorUtil.cleanVersion("1.2.3-dev.4"),
+                "cleanVersion should convert Maven-style dev version to PEP 440");
+    }
+
+    // --- isValidVersion ---
+
+    @Test
+    void testIsValidVersionStable() {
+        assertTrue(PythonCodeGeneratorUtil.isValidVersion("1.2.3"),
+                "stable X.Y.Z should be valid");
+    }
+
+    @Test
+    void testIsValidVersionDevFormat() {
+        assertTrue(PythonCodeGeneratorUtil.isValidVersion("1.2.3-dev.4"),
+                "X.Y.Z-dev.N should be valid");
+    }
+
+    @Test
+    void testIsValidVersionSnapshotFormat() {
+        assertTrue(PythonCodeGeneratorUtil.isValidVersion("0.0.0.featuremaster-Python-Update-SNAPSHOT"),
+                "X.Y.Z.<branch>-SNAPSHOT should be valid");
+    }
+
+    @Test
+    void testIsValidVersionSnapshotWithUnderscoreInBranch() {
+        assertTrue(PythonCodeGeneratorUtil.isValidVersion(
+                "0.0.0.aanta_677ea5142b8d666852cae77-4784-CDM6-ProposedWorkflowStepFix_UpdExp-SNAPSHOT"),
+                "SNAPSHOT branch qualifier containing underscores should be valid");
+    }
+
+    @Test
+    void testIsValidVersionNullReturnsFalse() {
+        assertFalse(PythonCodeGeneratorUtil.isValidVersion(null),
+                "null should not be valid");
+    }
+
+    @Test
+    void testIsValidVersionTooFewSegments() {
+        assertFalse(PythonCodeGeneratorUtil.isValidVersion("1.0"),
+                "X.Y is not a valid version");
+    }
+
+    @Test
+    void testIsValidVersionNonNumericSegment() {
+        assertFalse(PythonCodeGeneratorUtil.isValidVersion("1.a.0"),
+                "non-numeric segment should not be valid");
+    }
+
+    @Test
+    void testIsValidVersionSnapshotWithoutBranchQualifier() {
+        assertFalse(PythonCodeGeneratorUtil.isValidVersion("1.0.0-SNAPSHOT"),
+                "bare -SNAPSHOT without branch qualifier should not be valid");
+    }
+
+    @Test
+    void testIsValidVersionPep440DevIsNotValidInput() {
+        assertFalse(PythonCodeGeneratorUtil.isValidVersion("1.2.3.dev4"),
+                "PEP 440 output format X.Y.Z.devN is not a valid raw input version");
     }
 }


### PR DESCRIPTION
removed duplicated checking from `PythonCodeGeneratorCLI.java` and consolidated into `PythonCodeGeneratorUtil.java`

updated unit tests