### PR TITLE
Support more flexible version strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <repoServerHost>s01.oss.sonatype.org</repoServerHost>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rosetta.dsl.version>10.0.0</rosetta.dsl.version>
+        <rosetta.dsl.version>10.0.1</rosetta.dsl.version>
 
         <xtext.version>2.43.0</xtext.version>
         <guice.version>6.0.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <repoServerHost>s01.oss.sonatype.org</repoServerHost>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rosetta.dsl.version>10.0.1</rosetta.dsl.version>
+        <rosetta.dsl.version>10.0.0</rosetta.dsl.version>
 
         <xtext.version>2.43.0</xtext.version>
         <guice.version>6.0.0</guice.version>

--- a/python-test/cdm-tests/run_cdm_tests.sh
+++ b/python-test/cdm-tests/run_cdm_tests.sh
@@ -28,6 +28,8 @@ usage() {
     echo "  -k, --keep-venv           Skip cleanup of the virtual environment"
     echo "  -s, --skip-cdm            Skip CDM fetch and build (use existing wheel)"
     echo "  -v <version>              CDM branch/tag to fetch (default: master)"
+    echo "  --cdm-repo <url>          CDM git repo URL (default: finos/common-domain-model)"
+    echo "  --fpml-repo <url>         FpML git repo URL (default: rosetta-models/rune-fpml)"
     echo "  -h, --help                Show this help"
 }
 
@@ -35,6 +37,8 @@ REUSE_ENV=0
 SKIP_CDM=0
 CLEANUP=1
 CDM_VERSION="master"
+CDM_REPO="https://github.com/finos/common-domain-model.git"
+FPML_REPO="https://github.com/rosetta-models/rune-fpml.git"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -55,6 +59,14 @@ while [[ $# -gt 0 ]]; do
             CDM_VERSION="$2"
             shift 2
             ;;
+        --cdm-repo)
+            CDM_REPO="$2"
+            shift 2
+            ;;
+        --fpml-repo)
+            FPML_REPO="$2"
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -69,7 +81,7 @@ done
 
 if [[ $SKIP_CDM -eq 0 ]]; then
     echo "***** Fetching and building CDM version: $CDM_VERSION..."
-    "$MY_PATH/setup/build_cdm.sh" "$CDM_VERSION" || exit 1
+    "$MY_PATH/setup/build_cdm.sh" "$CDM_VERSION" --cdm-repo "$CDM_REPO" --fpml-repo "$FPML_REPO" || exit 1
 else
     echo "***** Skipping CDM fetch and build (using existing wheel)"
 fi

--- a/python-test/cdm-tests/run_cdm_tests.sh
+++ b/python-test/cdm-tests/run_cdm_tests.sh
@@ -27,7 +27,8 @@ usage() {
     echo "  -r, --reuse-env           Reuse the existing virtual environment"
     echo "  -k, --keep-venv           Skip cleanup of the virtual environment"
     echo "  -s, --skip-cdm            Skip CDM fetch and build (use existing wheel)"
-    echo "  -v <version>              CDM branch/tag to fetch (default: master)"
+    echo "  -b <branch>               CDM branch/tag to fetch (default: master)"
+    echo "  -v, --cdm-version <ver>   Version string passed to the generator (default: from build_cdm.sh)"
     echo "  --cdm-repo <url>          CDM git repo URL (default: finos/common-domain-model)"
     echo "  --fpml-repo <url>         FpML git repo URL (default: rosetta-models/rune-fpml)"
     echo "  -h, --help                Show this help"
@@ -36,9 +37,10 @@ usage() {
 REUSE_ENV=0
 SKIP_CDM=0
 CLEANUP=1
-CDM_VERSION="master"
+CDM_BRANCH="master"
 CDM_REPO="https://github.com/finos/common-domain-model.git"
 FPML_REPO="https://github.com/rosetta-models/rune-fpml.git"
+CDM_VERSION=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -55,7 +57,11 @@ while [[ $# -gt 0 ]]; do
             SKIP_CDM=1
             shift
             ;;
-        -v)
+        -b)
+            CDM_BRANCH="$2"
+            shift 2
+            ;;
+        -v|--cdm-version)
             CDM_VERSION="$2"
             shift 2
             ;;
@@ -80,8 +86,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $SKIP_CDM -eq 0 ]]; then
-    echo "***** Fetching and building CDM version: $CDM_VERSION..."
-    "$MY_PATH/setup/build_cdm.sh" "$CDM_VERSION" --cdm-repo "$CDM_REPO" --fpml-repo "$FPML_REPO" || exit 1
+    echo "***** Fetching and building CDM branch: $CDM_BRANCH..."
+    "$MY_PATH/setup/build_cdm.sh" "$CDM_BRANCH" --cdm-repo "$CDM_REPO" --fpml-repo "$FPML_REPO" ${CDM_VERSION:+--cdm-version "$CDM_VERSION"} || exit 1
 else
     echo "***** Skipping CDM fetch and build (using existing wheel)"
 fi

--- a/python-test/cdm-tests/setup/build_cdm.sh
+++ b/python-test/cdm-tests/setup/build_cdm.sh
@@ -53,7 +53,7 @@ PYTHON_SETUP_PATH="$MY_PATH/../../env-setup"
 JAR_PATH="$PROJECT_ROOT_PATH/target/python-0.0.0.main-SNAPSHOT.jar"
 CDM_PROJECT_NAME="finos-cdm"
 CDM_PREFIX="finos"
-CDM_VERSION="0.0.0.aanta_677ea5142b8d666852cae77-4784-CDM6-ProposedWorkflowStepFix_UpdExp-SNAPSHOT"
+CDM_VERSION="7.0.0-dev.98"
 cd ${MY_PATH} || error
 
 

--- a/python-test/cdm-tests/setup/build_cdm.sh
+++ b/python-test/cdm-tests/setup/build_cdm.sh
@@ -82,6 +82,10 @@ while [[ $# -gt 0 ]]; do
       FPML_REPO="$2"
       shift 2
       ;;
+    -v|--cdm-version)
+      CDM_VERSION="$2"
+      shift 2
+      ;;
     *)
       CDM_BRANCH="$1"
       shift

--- a/python-test/cdm-tests/setup/build_cdm.sh
+++ b/python-test/cdm-tests/setup/build_cdm.sh
@@ -53,7 +53,7 @@ PYTHON_SETUP_PATH="$MY_PATH/../../env-setup"
 JAR_PATH="$PROJECT_ROOT_PATH/target/python-0.0.0.main-SNAPSHOT.jar"
 CDM_PROJECT_NAME="finos-cdm"
 CDM_PREFIX="finos"
-CDM_VERSION="7.0.0-dev.98"
+CDM_VERSION="0.0.0.aanta_677ea5142b8d666852cae77-4784-CDM6-ProposedWorkflowStepFix_UpdExp-SNAPSHOT"
 cd ${MY_PATH} || error
 
 
@@ -61,26 +61,37 @@ source "$MY_PATH/../../ensure_jar_exists.sh" || { echo "Failed to source ensure_
 
 # Parse command-line arguments
 CDM_BRANCH="master"
-# CDM_BRANCH="6.x.x"
+CDM_REPO="https://github.com/finos/common-domain-model.git"
+FPML_REPO="https://github.com/rosetta-models/rune-fpml.git"
 SKIP_CDM=0
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --skip-cdm)
       SKIP_CDM=1
+      shift
       ;;
     -r|--reuse-env)
       export REUSE_ENV=1
+      shift
+      ;;
+    --cdm-repo)
+      CDM_REPO="$2"
+      shift 2
+      ;;
+    --fpml-repo)
+      FPML_REPO="$2"
+      shift 2
       ;;
     *)
-      # default any other argument to the CDM version
-      CDM_BRANCH="$arg"
+      CDM_BRANCH="$1"
+      shift
       ;;
   esac
 done
 
 if [[ $SKIP_CDM -eq 0 ]]; then
     echo "***** Fetching CDM version: $CDM_BRANCH"
-    source $MY_PATH/get_cdm.sh "$CDM_BRANCH"
+    source $MY_PATH/get_cdm.sh "$CDM_BRANCH" --cdm-repo "$CDM_REPO" --fpml-repo "$FPML_REPO"
 else
     echo "Skipping get_cdm.sh as requested."
 fi

--- a/python-test/cdm-tests/setup/get_cdm.sh
+++ b/python-test/cdm-tests/setup/get_cdm.sh
@@ -31,9 +31,23 @@ echo "***** resetting the rosetta directory"
 rm -rf "${ROSETTA_DIR}"
 mkdir -p "${ROSETTA_DIR}/common-domain-model"
 
-CDM_BRANCH=${1:-"master"}
+CDM_BRANCH="${1:-master}"
+CDM_REMOTE="https://github.com/finos/common-domain-model.git"
+FPML_REMOTE="https://github.com/rosetta-models/rune-fpml.git"
 
-echo "***** pull CDM rosetta definitions ($CDM_BRANCH)"
+idx=2
+while [ $idx -le $# ]; do
+    arg="${!idx}"
+    ((next_idx=idx+1))
+    val="${!next_idx}"
+    case "$arg" in
+        --cdm-repo)  CDM_REMOTE="$val"; ((idx+=2)) ;;
+        --fpml-repo) FPML_REMOTE="$val"; ((idx+=2)) ;;
+        *) ((idx++)) ;;
+    esac
+done
+
+echo "***** pull CDM rosetta definitions ($CDM_BRANCH from $CDM_REMOTE)"
 TEMP_CDM="${MY_PATH}/../temp_cdm"
 rm -rf "${TEMP_CDM}"
 mkdir -p "${TEMP_CDM}"
@@ -47,18 +61,16 @@ pom.xml
 rosetta-source/pom.xml
 EOF
 
-git remote add origin https://github.com/finos/common-domain-model.git
+git remote add origin "$CDM_REMOTE"
 git pull --depth 1 origin $CDM_BRANCH || error "git pull for CDM failed"
 
 # Copy CDM files to the target 'common-domain-model' folder
 cp -r rosetta-source/src/main/rosetta/* "${ROSETTA_DIR}/common-domain-model/"
 
-# Check for rune-fpml[-.]version property in pom.xml
 FPML_VERSION=$(sed -n 's/.*<rune-fpml[-.]version>\(.*\)<\/rune-fpml[-.]version>.*/\1/p' pom.xml | head -n 1)
 
 if [ -n "$FPML_VERSION" ]; then
-    echo "***** Found rune-fpml-version: $FPML_VERSION"
-    echo "***** pulling FpML definitions from https://github.com/rosetta-models/rune-fpml"
+    echo "***** pulling FpML definitions ($FPML_VERSION from $FPML_REMOTE)"
 
     mkdir -p "${ROSETTA_DIR}/rune-fpml"
 
@@ -70,7 +82,7 @@ if [ -n "$FPML_VERSION" ]; then
     git init
     git config core.sparseCheckout true
     echo "rosetta-source/src/main/rosetta/*" >> .git/info/sparse-checkout
-    git remote add origin https://github.com/rosetta-models/rune-fpml.git
+    git remote add origin "$FPML_REMOTE"
 
     # Attempt to pull the specific version/tag, fallback to master if it fails
     git pull --depth 1 origin "$FPML_VERSION" || {

--- a/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
@@ -16,7 +16,7 @@ public final class PythonCodeGeneratorUtil {
 
     public static final Pattern VALID_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
     public static final Pattern DEV_VERSION_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+)-dev\\.(\\d+)");
-    public static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+)\\.[A-Za-z][A-Za-z0-9_-]+-SNAPSHOT");
+    public static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+).*-SNAPSHOT");
     private static final Pattern PEP440_DEV_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.dev\\d+");
 
     private PythonCodeGeneratorUtil() {

--- a/src/test/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtilTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtilTest.java
@@ -133,8 +133,22 @@ class PythonCodeGeneratorUtilTest {
 
     @Test
     void testIsValidVersionSnapshotWithoutBranchQualifier() {
-        assertFalse(PythonCodeGeneratorUtil.isValidVersion("1.0.0-SNAPSHOT"),
-                "bare -SNAPSHOT without branch qualifier should not be valid");
+        assertTrue(PythonCodeGeneratorUtil.isValidVersion("1.0.0-SNAPSHOT"),
+                "bare -SNAPSHOT without branch qualifier should be valid");
+    }
+
+    @Test
+    void testCleanVersionSnapshotWithDotInBranchQualifier() {
+        assertEquals("0.0.0.dev0",
+                PythonCodeGeneratorUtil.cleanVersion("0.0.0.erin._68bf072a8b2a2bdff21c85a-as-syntax_UpdatedExpectations-SNAPSHOT"),
+                "cleanVersion should handle SNAPSHOT branch qualifiers containing dots");
+    }
+
+    @Test
+    void testIsValidVersionSnapshotWithDotInBranchQualifier() {
+        assertTrue(PythonCodeGeneratorUtil.isValidVersion(
+                "0.0.0.erin._68bf072a8b2a2bdff21c85a-as-syntax_UpdatedExpectations-SNAPSHOT"),
+                "SNAPSHOT branch qualifier containing dots should be valid");
     }
 
     @Test


### PR DESCRIPTION
### Summary

**Relax SNAPSHOT version pattern in PythonCodeGeneratorUtil**: replace the restrictive character-class qualifier ([A-Za-z][A-Za-z0-9_-]+) with .*, accepting any characters between the numeric prefix and -SNAPSHOT. This fixes rejection of CDM development branch versions where the branch name contains dots (e.g., 0.0.0.erin._68bf072a8b2a2bdff21c85a-as-syntax_UpdatedExpectations-SNAPSHOT). The output mapping is unchanged — any X.Y.Z.*-SNAPSHOT still converts to X.Y.Z.dev0.

**Update SNAPSHOT_VERSION_PATTERN tests**: adjust the bare -SNAPSHOT test to reflect the relaxed rule (now accepted), and add two new test cases for dot-containing branch qualifiers — one for cleanVersion, one for isValidVersion.

**Separate branch and version flags in CDM test scripts**: split the previous overloaded -v flag (branch) into -b <branch> for the CDM git branch and -v/--cdm-version <ver> for the version string passed to the generator. This allows testing a specific CDM repo branch while controlling the Python package version independently. Renames the internal CDM_VERSION variable to CDM_BRANCH in run_cdm_tests.sh for clarity.

**Update DSL version***: 10.0.1

**Test plan**
 PythonCodeGeneratorUtilTest passes: mvn test -Dtest=PythonCodeGeneratorUtilTest
 0.0.0.erin._68bf072a8b2a2bdff21c85a-as-syntax_UpdatedExpectations-SNAPSHOT → 0.0.0.dev0 via cleanVersion
 ./python-test/cdm-tests/run_cdm_tests.sh -b <branch> -v <version> invokes build_cdm.sh with both values correctly