### PR TITLE
feat: update JUnit and Python unit tests to have same coverage as Rune-DSL

### DIFF
--- a/python-test/unit-tests/features/expressions/Constructor.rosetta
+++ b/python-test/unit-tests/features/expressions/Constructor.rosetta
@@ -1,0 +1,31 @@
+namespace rosetta_dsl.test.expressions.constructor
+
+type Foo:
+    a int (1..1)
+    b int (0..1)
+
+type Item:
+    val int (1..1)
+
+type Container:
+    items Item (0..*)
+
+func BuildFooComplete:
+    inputs: seed int (1..1)
+    output: result Foo (1..1)
+    set result:
+        Foo { a: seed, b: 2 }
+
+func BuildFooPartial:
+    inputs: val int (1..1)
+    output: result Foo (1..1)
+    set result:
+        Foo { a: val, ... }
+
+func BuildContainer:
+    inputs: n int (1..1)
+    output: result Container (1..1)
+    set result:
+        Container {
+            items: [ Item { val: 1 }, Item { val: 2 }, Item { val: n } ]
+        }

--- a/python-test/unit-tests/features/expressions/EmptyEvaluation.rosetta
+++ b/python-test/unit-tests/features/expressions/EmptyEvaluation.rosetta
@@ -1,0 +1,17 @@
+namespace rosetta_dsl.test.expressions.empty_evaluation
+
+type Foo:
+    someBoolean boolean (0..1)
+    alwaysFalse boolean (1..1)
+
+func IsAbsent:
+    inputs: foo Foo (1..1)
+    output: result boolean (1..1)
+    set result:
+        foo -> someBoolean is absent
+
+func IsPresent:
+    inputs: foo Foo (1..1)
+    output: result boolean (1..1)
+    set result:
+        foo -> someBoolean exists

--- a/python-test/unit-tests/features/expressions/SortClosure.rosetta
+++ b/python-test/unit-tests/features/expressions/SortClosure.rosetta
@@ -9,3 +9,15 @@ func SortItems:
     output: result SortItem (0..*)
     set result:
         items sort [ item -> val1 ]
+
+func SortItemsBySecondField:
+    inputs: items SortItem (0..*)
+    output: result SortItem (0..*)
+    set result:
+        items sort [ item -> val2 ]
+
+func SortIntegers:
+    inputs: items int (0..*)
+    output: result int (0..*)
+    set result:
+        items sort

--- a/python-test/unit-tests/features/expressions/test_constructor.py
+++ b/python-test/unit-tests/features/expressions/test_constructor.py
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Constructor expression runtime tests."""
+
+from rosetta_dsl.test.expressions.constructor.Foo import Foo
+from rosetta_dsl.test.expressions.constructor.Item import Item
+from rosetta_dsl.test.expressions.constructor.Container import Container
+from rosetta_dsl.test.expressions.constructor.functions.BuildFooComplete import BuildFooComplete
+from rosetta_dsl.test.expressions.constructor.functions.BuildFooPartial import BuildFooPartial
+from rosetta_dsl.test.expressions.constructor.functions.BuildContainer import BuildContainer
+
+
+def test_constructor_with_all_fields():
+    """Foo { a: seed, b: 2 } populates both fields."""
+    result = BuildFooComplete(seed=1)
+    assert result.a == 1
+    assert result.b == 2
+
+
+def test_constructor_with_ellipsis_omits_optional_field():
+    """Foo { a: val, ... } leaves the optional field b as None."""
+    result = BuildFooPartial(val=42)
+    assert result.a == 42
+    assert result.b is None
+
+
+def test_constructor_with_list_literal():
+    """Container { items: [...] } produces a list of the specified items."""
+    result = BuildContainer(n=3)
+    assert isinstance(result, Container)
+    assert len(result.items) == 3
+    assert result.items[0].val == 1
+    assert result.items[1].val == 2
+    assert result.items[2].val == 3

--- a/python-test/unit-tests/features/expressions/test_empty_evaluation.py
+++ b/python-test/unit-tests/features/expressions/test_empty_evaluation.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Empty / absent value evaluation runtime tests.
+
+Mirrors EmptyEvaluationTest in the rune-dsl Java generator tests, adapted for
+the Python generator's runtime: optional attributes default to None, is-absent
+returns True when the attribute is None, and exists returns True when it is set.
+"""
+
+from rosetta_dsl.test.expressions.empty_evaluation.Foo import Foo
+from rosetta_dsl.test.expressions.empty_evaluation.functions.IsAbsent import IsAbsent
+from rosetta_dsl.test.expressions.empty_evaluation.functions.IsPresent import IsPresent
+
+
+def test_is_absent_when_none():
+    """is absent returns True when the optional attribute is None."""
+    foo = Foo(someBoolean=None, alwaysFalse=False)
+    assert IsAbsent(foo=foo) is True
+
+
+def test_is_absent_when_set():
+    """is absent returns False when the optional attribute has a value."""
+    foo = Foo(someBoolean=True, alwaysFalse=False)
+    assert IsAbsent(foo=foo) is False
+
+
+def test_exists_when_set():
+    """exists returns True when the optional attribute is set."""
+    foo = Foo(someBoolean=True, alwaysFalse=False)
+    assert IsPresent(foo=foo) is True
+
+
+def test_exists_when_none():
+    """exists returns False when the optional attribute is None."""
+    foo = Foo(someBoolean=None, alwaysFalse=False)
+    assert IsPresent(foo=foo) is False

--- a/python-test/unit-tests/features/expressions/test_sort_closure.py
+++ b/python-test/unit-tests/features/expressions/test_sort_closure.py
@@ -3,15 +3,42 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-"""Sort Closure expression unit tests"""
+"""Sort closure expression unit tests."""
 
 from rosetta_dsl.test.expressions.sort_closure.SortItem import SortItem
 from rosetta_dsl.test.expressions.sort_closure.functions.SortItems import SortItems
+from rosetta_dsl.test.expressions.sort_closure.functions.SortItemsBySecondField import (
+    SortItemsBySecondField,
+)
+from rosetta_dsl.test.expressions.sort_closure.functions.SortIntegers import SortIntegers
 
 
 def test_sort_closure():
-    """Test sort closure expression."""
+    """Sort complex objects by key field val1."""
     items = [SortItem(val1=5, val2=10), SortItem(val1=1, val2=100)]
-
     expected = [SortItem(val1=1, val2=100), SortItem(val1=5, val2=10)]
     assert SortItems(items=items) == expected
+
+
+def test_sort_by_second_field():
+    """Sort complex objects by key field val2."""
+    items = [SortItem(val1=5, val2=100), SortItem(val1=1, val2=10)]
+    result = SortItemsBySecondField(items=items)
+    expected = [SortItem(val1=1, val2=10), SortItem(val1=5, val2=100)]
+    assert result == expected
+
+
+def test_sort_integers_no_key():
+    """Plain sort without a key expression sorts a list of integers."""
+    items = [3, 1, 4, 1, 5, 9, 2]
+    result = SortIntegers(items=items)
+    assert result == [1, 1, 2, 3, 4, 5, 9]
+
+
+def test_sort_preserves_all_non_null_items():
+    """All non-null items survive the sort; order is ascending by key."""
+    items = [SortItem(val1=10, val2=1), SortItem(val1=2, val2=5)]
+    result = SortItems(items=items)
+    assert len(result) == 2
+    assert result[0].val1 == 2
+    assert result[1].val1 == 10

--- a/python-test/unit-tests/features/language/TypeAliasCondition.rosetta
+++ b/python-test/unit-tests/features/language/TypeAliasCondition.rosetta
@@ -1,0 +1,16 @@
+namespace rosetta_dsl.test.language.type_alias_condition
+
+typeAlias StringCode:
+    string
+
+    condition ValidCode:
+        item <> "INVALID"
+
+type CodeHolder:
+    code StringCode (1..1)
+
+func BuildCodeHolder:
+    inputs: code string (1..1)
+    output: result CodeHolder (1..1)
+    set result:
+        CodeHolder { code: code }

--- a/python-test/unit-tests/features/language/test_type_alias_condition.py
+++ b/python-test/unit-tests/features/language/test_type_alias_condition.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Type alias condition tests.
+
+Known gap: the Python generator strips type aliases to their underlying
+primitive types (e.g. StringCode -> str).  Conditions defined on the
+type alias (e.g. ValidCode: item <> "INVALID") are NOT enforced at
+runtime in Python.
+
+The Java generator, by contrast, generates a named validator (e.g.
+StringCodeValidCode) that fires whenever an attribute of that alias
+type is validated.
+
+These tests document current behaviour: the alias is transparent and
+the underlying primitive is used without condition enforcement.
+
+Mirrors TypeAliasConditionTest in the rune-dsl Java generator tests.
+"""
+
+from rosetta_dsl.test.language.type_alias_condition.CodeHolder import CodeHolder
+from rosetta_dsl.test.language.type_alias_condition.functions.BuildCodeHolder import (
+    BuildCodeHolder,
+)
+
+
+def test_type_alias_reduces_to_underlying_type():
+    """CodeHolder.code is a plain str field; the alias name is transparent."""
+    holder = BuildCodeHolder(code="VALID")
+    assert holder.code == "VALID"
+    assert isinstance(holder.code, str)
+
+
+def test_type_alias_condition_is_not_enforced():
+    """
+    Known gap: the ValidCode condition (item <> 'INVALID') is not enforced
+    in Python.  A value that violates the alias condition is accepted without
+    raising an error.
+    """
+    # This would fail validation in the Java generator but is silently accepted here.
+    holder = BuildCodeHolder(code="INVALID")
+    assert holder.code == "INVALID"  # condition NOT enforced

--- a/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonCollectionExpressionTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonCollectionExpressionTest.java
@@ -887,6 +887,29 @@ public class PythonCollectionExpressionTest {
     // From PythonReduceOperationTest
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+    // From RosettaSortOperationTest — sort with key expression
+    // -------------------------------------------------------------------------
+
+    /**
+     * {@code items sort [ item -> val ]} generates a sort with a {@code key=} lambda
+     * that uses {@code rune_resolve_attr} to extract the key field.
+     */
+    @Test
+    public void testSortWithKeyExpression() {
+        testUtils.assertBundleContainsExpectedString("""
+                type SortItem:
+                    val int (1..1)
+
+                func SortByVal:
+                    inputs: items SortItem (0..*)
+                    output: result SortItem (0..*)
+                    set result:
+                        items sort [ item -> val ]
+                """,
+                "(lambda items: sorted((x for x in (items or []) if x is not None), key=lambda item: rune_resolve_attr(item, \"val\")) if items is not None else None)(rune_resolve_attr(self, \"items\"))");
+    }
+
     @Test
     public void testReduceOperation() {
         Map<String, CharSequence> gf = testUtils.generatePythonFromString(

--- a/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonCountOperationTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonCountOperationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.regnosys.rosetta.generator.python.expressions;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.generator.python.PythonGeneratorTestUtils;
+import com.regnosys.rosetta.tests.RosettaInjectorProvider;
+
+import jakarta.inject.Inject;
+
+/**
+ * Dedicated tests for the {@code count} operation in generated Python.
+ *
+ * <p>The count generator emits an inline lambda that uses {@code sum(1 for x in ...
+ * if x is not None)}, correctly filtering {@code None} elements.  This class verifies
+ * that pattern in several contexts: function body, condition, and chained after map/filter.
+ *
+ * <p>Mirrors {@code RosettaCountOperationTest} in the rune-dsl Java generator tests.
+ */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaInjectorProvider.class)
+@SuppressWarnings("LineLength")
+public class PythonCountOperationTest {
+
+    private static final String COUNT_LAMBDA_PREFIX =
+            "(lambda items: sum(1 for x in (items if (hasattr(items, '__iter__') and not isinstance(items, (str, dict, bytes, bytearray))) else ([items] if items is not None else [])) if x is not None))";
+
+    @Inject
+    private PythonGeneratorTestUtils testUtils;
+
+    /**
+     * {@code items count} used as a function return value generates the count lambda.
+     */
+    @Test
+    public void testCountOnFunctionInputGeneratesLambda() {
+        testUtils.assertBundleContainsExpectedString("""
+                func CountItems:
+                    inputs: items int (0..*)
+                    output: result int (1..1)
+                    set result:
+                        items count
+                """,
+                COUNT_LAMBDA_PREFIX + "(rune_resolve_attr(self, \"items\"))");
+    }
+
+    /**
+     * {@code [1, 2, 3] count} — count on a list literal.
+     */
+    @Test
+    public void testCountOnListLiteralGeneratesLambda() {
+        testUtils.assertBundleContainsExpectedString("""
+                func CountLiteral:
+                    output: result int (1..1)
+                    set result:
+                        [1, 2, 3] count
+                """,
+                COUNT_LAMBDA_PREFIX + "([1, 2, 3])");
+    }
+
+    /**
+     * {@code items count = 3} in a condition generates an equality comparison
+     * wrapped in {@code rune_all_elements}.
+     */
+    @Test
+    public void testCountEqualityInConditionWrapsAllElements() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Box:
+                    values int (0..*)
+                    condition ThreeValues:
+                        values count = 3
+                """,
+                "return rune_all_elements(" + COUNT_LAMBDA_PREFIX + "(rune_resolve_attr(self, \"values\")), \"=\", 3)");
+    }
+
+    /**
+     * {@code field1 count > 0} — count with a greater-than comparison.
+     */
+    @Test
+    public void testCountGreaterThanZeroInCondition() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Holder:
+                    tags string (0..*)
+                    condition HasTags:
+                        tags count > 0
+                """,
+                COUNT_LAMBDA_PREFIX + "(rune_resolve_attr(self, \"tags\"))");
+    }
+
+    /**
+     * Count on an extracted attribute path: {@code aValue -> field1 count}.
+     * The path resolution is wrapped in the same count lambda.
+     */
+    @Test
+    public void testCountOnAttributePath() {
+        testUtils.assertBundleContainsExpectedString("""
+                type A:
+                    field1 int (0..*)
+
+                type B:
+                    a A (1..1)
+                    condition FieldCount:
+                        a -> field1 count = 2
+                """,
+                COUNT_LAMBDA_PREFIX + "(rune_resolve_attr(rune_resolve_attr(self, \"a\"), \"field1\"))");
+    }
+
+    /**
+     * Comparing two count expressions: {@code field1 count <> field2 count}.
+     */
+    @Test
+    public void testCountComparisonBetweenTwoFields() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Data:
+                    field1 int (0..*)
+                    field2 int (0..*)
+                    condition DifferentLengths:
+                        field1 count <> field2 count
+                """,
+                COUNT_LAMBDA_PREFIX + "(rune_resolve_attr(self, \"field1\"))");
+    }
+}

--- a/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonDeepPathTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonDeepPathTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.regnosys.rosetta.generator.python.expressions;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.generator.python.PythonGeneratorTestUtils;
+import com.regnosys.rosetta.tests.RosettaInjectorProvider;
+
+import jakarta.inject.Inject;
+
+/**
+ * Tests for deep-path expressions ({@code item->>attr}), which resolve an attribute
+ * across a polymorphic choice structure.
+ *
+ * <p>The deep-path operator is valid when the receiver type is a choice (one-of) whose
+ * branches all provide the named attribute (directly or transitively).  Each test
+ * therefore uses a type with two optional branches and a {@code one-of} condition.
+ *
+ * <p>Mirrors {@code DeepPathTest} in the rune-dsl Java generator tests.
+ */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaInjectorProvider.class)
+@SuppressWarnings("LineLength")
+public class PythonDeepPathTest {
+
+    @Inject
+    private PythonGeneratorTestUtils testUtils;
+
+    /**
+     * A container type with two choice branches each having a common attribute generates
+     * {@code rune_resolve_deep_attr} for {@code item->>val}.
+     */
+    @Test
+    public void testSimpleDeepPathInCondition() {
+        testUtils.assertBundleContainsExpectedString("""
+                type BranchA:
+                    val int (1..1)
+
+                type BranchB:
+                    val int (1..1)
+
+                type Container:
+                    a BranchA (0..1)
+                    b BranchB (0..1)
+                    condition Choice: one-of
+                    condition DeepCheck:
+                        item->>val = 5
+                """,
+                "rune_resolve_deep_attr(self, \"val\")");
+    }
+
+    /**
+     * Deep path followed by a feature call: {@code item->>leaf->val} where both
+     * branches of the choice type expose the nested {@code leaf} attribute.
+     */
+    @Test
+    public void testDeepPathFollowedByFeatureCall() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Leaf:
+                    val int (1..1)
+
+                type BranchX:
+                    leaf Leaf (1..1)
+
+                type BranchY:
+                    leaf Leaf (1..1)
+
+                type Root:
+                    x BranchX (0..1)
+                    y BranchY (0..1)
+                    condition Choice: one-of
+                    condition DeepAttrCheck:
+                        item->>leaf->val = 10
+                """,
+                "rune_resolve_deep_attr(self, \"leaf\")");
+    }
+
+    /**
+     * Deep path used in a multi-level type hierarchy condition (the passing baseline
+     * from the rune-dsl test suite).
+     */
+    @Test
+    public void testDeepPathAcrossInheritanceHierarchy() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Deep1:
+                    attr int (1..1)
+
+                type Bar1:
+                    deep1 Deep1 (1..1)
+                    b1 int (1..1)
+                    a int (1..1)
+
+                type Bar2:
+                    deep1 Deep1 (1..1)
+                    b1 int (1..1)
+                    c int (1..1)
+
+                type Bar4:
+                    deep1 Deep1 (1..1)
+                    b1 int (1..1)
+
+                type Bar3:
+                    bar2 Bar2 (0..1)
+                    bar4 Bar4 (0..1)
+                    condition Choice: one-of
+
+                type Foo:
+                    bar1 Bar1 (0..1)
+                    bar3 Bar3 (0..1)
+                    condition Choice: one-of
+                    condition Test:
+                        item->>deep1->attr = 3
+                """,
+                "rune_resolve_deep_attr(self, \"deep1\")");
+    }
+
+    /**
+     * Deep path on a named (non-{@code item}) receiver: {@code inner->>val} where
+     * {@code inner} is a choice type whose branches each have {@code val}.
+     */
+    @Test
+    public void testDeepPathOnExplicitReceiver() {
+        testUtils.assertBundleContainsExpectedString("""
+                type LeftBranch:
+                    val int (1..1)
+
+                type RightBranch:
+                    val int (1..1)
+
+                type Inner:
+                    left LeftBranch (0..1)
+                    right RightBranch (0..1)
+                    condition Choice: one-of
+
+                type Wrapper:
+                    inner Inner (1..1)
+
+                    condition DeepCheck:
+                        inner->>val = 7
+                """,
+                "rune_resolve_deep_attr");
+    }
+}

--- a/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonEmptyEvaluationTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonEmptyEvaluationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.regnosys.rosetta.generator.python.expressions;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.generator.python.PythonGeneratorTestUtils;
+import com.regnosys.rosetta.tests.RosettaInjectorProvider;
+
+import jakarta.inject.Inject;
+
+/**
+ * Tests for expressions involving absent/empty values.
+ *
+ * <p>The Java generator's {@code EmptyEvaluationTest} operates at expression-evaluation
+ * level using compiled Java. For the Python generator we assert on the generated source
+ * for equivalent patterns: optional attributes, conditionals without an else branch, and
+ * absent-value checks within boolean expressions.
+ *
+ * <p>Mirrors {@code EmptyEvaluationTest} in the rune-dsl Java generator tests.
+ */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaInjectorProvider.class)
+@SuppressWarnings("LineLength")
+public class PythonEmptyEvaluationTest {
+
+    @Inject
+    private PythonGeneratorTestUtils testUtils;
+
+    /**
+     * A conditional with no {@code else} branch generates a Python ternary
+     * whose false-arm is {@code None} (representing empty).
+     */
+    @Test
+    public void testConditionalWithNoElseBranchGeneratesNoneFallback() {
+        testUtils.assertBundleContainsExpectedString("""
+                func TestNoElse:
+                    inputs: flag boolean (1..1)
+                    output: result boolean (0..1)
+                    set result:
+                        if flag then True
+                """,
+                "if_cond_fn");
+    }
+
+    /**
+     * An optional attribute field generates an {@code Optional} Python type.
+     * Absent value semantics are upheld by the field defaulting to {@code None}.
+     */
+    @Test
+    public void testOptionalAttributeGeneratesNoneDefault() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Foo:
+                    someBoolean boolean (0..1)
+                    alwaysFalse boolean (1..1)
+                """,
+                "Optional[bool]");
+    }
+
+    /**
+     * {@code is absent} generates a negated {@code rune_attr_exists} call.
+     */
+    @Test
+    public void testIsAbsentGeneratesNegatedAttrExists() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Foo:
+                    val int (0..1)
+                    condition AbsentCheck:
+                        val is absent
+                """,
+                "(not rune_attr_exists(");
+    }
+
+    /**
+     * An OR expression where the left operand is an optional attribute generates
+     * correctly — the optional attribute resolves via {@code rune_resolve_attr}.
+     */
+    @Test
+    public void testAbsentOptionalInBooleanOrExpression() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Foo:
+                    someBoolean boolean (0..1)
+                    alwaysFalse boolean (1..1)
+                    condition OrCheck:
+                        someBoolean or alwaysFalse
+                """,
+                "rune_resolve_attr(self, \"someBoolean\")");
+    }
+
+    /**
+     * Accessing an optional attribute through a constructor expression generates a
+     * {@code rune_resolve_attr} call, not a direct field reference that would NPE.
+     */
+    @Test
+    public void testOptionalAttributeAccessViaConstructorExpression() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Foo:
+                    someBoolean boolean (0..1)
+                    alwaysFalse boolean (1..1)
+                    condition ConstructorAndOr:
+                        Foo { alwaysFalse: False, ... } -> someBoolean or Foo { alwaysFalse: False, ... } -> alwaysFalse
+                """,
+                "Foo(alwaysFalse=False)");
+    }
+
+    /**
+     * {@code exists} on an optional field generates a {@code rune_attr_exists} call.
+     */
+    @Test
+    public void testExistsOnOptionalFieldGeneratesAttrExistsCall() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Bar:
+                    val int (0..1)
+                    condition ExistsCheck:
+                        val exists
+                """,
+                "rune_attr_exists(rune_resolve_attr(self, \"val\"))");
+    }
+}

--- a/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonObjectExpressionTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonObjectExpressionTest.java
@@ -137,4 +137,80 @@ public class PythonObjectExpressionTest {
 
                     return result""");
     }
+
+    // -------------------------------------------------------------------------
+    // From ConstructorTest — derived-class override and nested list construction
+    // -------------------------------------------------------------------------
+
+    /**
+     * A derived class constructor that overrides a parent attribute with a
+     * more specific type generates the derived class name, not the parent's.
+     */
+    @Test
+    public void testDerivedClassConstructorUsesOverriddenType() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Parent:
+                type Child extends Parent:
+                    attr int (1..1)
+
+                type Holder:
+                    items Parent (0..*)
+
+                type ChildHolder extends Holder:
+                    override items Child (0..*)
+
+                func BuildChildHolder:
+                    output: result ChildHolder (1..1)
+                    set result:
+                        ChildHolder {
+                            items: [
+                                Child { attr: 1 },
+                                Child { attr: 2 }
+                            ]
+                        }
+                """,
+                "ChildHolder(items=[Child(attr=1), Child(attr=2)])");
+    }
+
+    /**
+     * A nested constructor with an ellipsis ({@code ...}) generates keyword
+     * arguments only for the explicitly provided fields; omitted fields use
+     * their Python defaults.
+     */
+    @Test
+    public void testConstructorWithEllipsisOmitsUnspecifiedFields() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Foo:
+                    a int (1..1)
+                    b int (0..1)
+
+                func BuildPartialFoo:
+                    output: result Foo (1..1)
+                    set result:
+                        Foo { a: 42, ... }
+                """,
+                "Foo(a=42)");
+    }
+
+    /**
+     * Constructor expression with a list literal generates a Python list.
+     */
+    @Test
+    public void testConstructorWithListLiteralGeneratesPythonList() {
+        testUtils.assertBundleContainsExpectedString("""
+                type Item:
+                    val int (1..1)
+
+                type Container:
+                    items Item (0..*)
+
+                func BuildContainer:
+                    output: result Container (1..1)
+                    set result:
+                        Container {
+                            items: [ Item { val: 1 }, Item { val: 2 }, Item { val: 3 } ]
+                        }
+                """,
+                "Container(items=[Item(val=1), Item(val=2), Item(val=3)])");
+    }
 }

--- a/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonTypeAliasConditionTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/expressions/PythonTypeAliasConditionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.regnosys.rosetta.generator.python.expressions;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.generator.python.PythonGeneratorTestUtils;
+import com.regnosys.rosetta.tests.RosettaInjectorProvider;
+
+import jakarta.inject.Inject;
+
+/**
+ * Tests documenting how type aliases are handled in generated Python.
+ *
+ * <p>In the Java generator, a {@code typeAlias} with a {@code condition} block
+ * generates a full validator that is invoked whenever the alias type is used as
+ * an attribute.  The Python generator instead strips type aliases to their
+ * underlying primitive (e.g. {@code Foo: string} → Python {@code str}) and does
+ * <em>not</em> generate any condition enforcement for the alias.
+ *
+ * <p>This class documents:
+ * <ol>
+ *   <li>Current behaviour: the alias maps to the correct Python primitive in
+ *       generated attribute declarations.</li>
+ *   <li>Known gap: conditions defined on the alias are not generated in Python
+ *       ({@link #testTypeAliasConditionNotGenerated}).</li>
+ * </ol>
+ *
+ * <p>Mirrors {@code TypeAliasConditionTest} in the rune-dsl Java generator tests.
+ */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaInjectorProvider.class)
+@SuppressWarnings("LineLength")
+public class PythonTypeAliasConditionTest {
+
+    @Inject
+    private PythonGeneratorTestUtils testUtils;
+
+    /**
+     * A {@code typeAlias} over {@code string} generates {@code str} for any
+     * attribute that uses it — the alias name is not preserved in Python.
+     */
+    @Test
+    public void testStringTypeAliasReducesToStr() {
+        testUtils.assertBundleContainsExpectedString("""
+                typeAlias Foo:
+                    string
+
+                type Bar:
+                    foo Foo (1..1)
+                """,
+                "foo: str");
+    }
+
+    /**
+     * A {@code typeAlias} over {@code int} generates {@code int} for attributes.
+     */
+    @Test
+    public void testIntTypeAliasReducesToInt() {
+        testUtils.assertBundleContainsExpectedString("""
+                typeAlias PosInt:
+                    int
+
+                type Wrapper:
+                    value PosInt (1..1)
+                """,
+                "value: int");
+    }
+
+    /**
+     * A chain of type aliases collapses to the base primitive.
+     * {@code Bar: Foo}, {@code Foo: string} → Python {@code str}.
+     */
+    @Test
+    public void testChainedTypeAliasReducesToBasePrimitive() {
+        testUtils.assertBundleContainsExpectedString("""
+                typeAlias Foo:
+                    string
+
+                typeAlias Bar:
+                    Foo
+
+                type Holder:
+                    val Bar (1..1)
+                """,
+                "val: str");
+    }
+
+    /**
+     * A function whose parameter type is an alias generates the underlying
+     * Python primitive in the function signature.
+     */
+    @Test
+    public void testTypeAliasParameterReducesToPrimitive() {
+        testUtils.assertBundleContainsExpectedString("""
+                typeAlias MyStr:
+                    string
+
+                func UseAlias:
+                    inputs: val MyStr (1..1)
+                    output: result string (1..1)
+                    set result: val
+                """,
+                "def UseAlias(val: str) -> str:");
+    }
+
+    /**
+     * Known gap: conditions defined on a {@code typeAlias} are not generated
+     * in Python.  In the Java generator these produce a named validator
+     * (e.g. {@code FooC}) that fires on every attribute of that alias type.
+     * The Python generator strips the alias to its primitive and emits no
+     * condition logic.
+     *
+     * <p>This test is disabled to document the gap without failing the build.
+     * When/if Python condition generation for type aliases is implemented,
+     * remove {@code @Disabled} and adjust the assertion.
+     */
+    @Disabled("Known gap: type alias conditions are not generated in Python — "
+            + "aliases are stripped to primitives; no condition validator is emitted")
+    @Test
+    public void testTypeAliasConditionNotGenerated() {
+        testUtils.assertBundleContainsExpectedString("""
+                typeAlias Foo:
+                    string
+
+                    condition C:
+                        item <> "forbidden"
+                """,
+                // In Java this condition becomes a validator named "FooC".
+                // In Python nothing is generated for it — this assertion fails.
+                "condition_0_C");
+    }
+}


### PR DESCRIPTION
### Overview

Increases JUnit and Python unit test coverage in the Python generator to mirror the test suite in `rune-dsl`. The branch adds dedicated test classes for expression categories that previously lacked explicit coverage, extends existing collection expression tests, and introduces a parallel set of Python unit tests that exercise the same features end-to-end through the generator and runtime.

---

### New JUnit Test Classes

| Class | Tests | Coverage area |
|---|---|---|
| `PythonCountOperationTest` | 6 | `count` lambda generation in function bodies, list literals, conditions, and field comparisons |
| `PythonDeepPathTest` | 4 | Deep path (`->>`) operator generation in conditions, feature calls, and inheritance hierarchies |
| `PythonEmptyEvaluationTest` | 6 | `absent` / `exists` evaluation, optional attribute defaults, `None` fallback in conditional expressions |
| `PythonObjectExpressionTest` | 6 | Constructor expressions including ellipsis (`...`) syntax and list-literal initialisation |
| `PythonTypeAliasConditionTest` | 4 + 1 disabled | Type alias reduction to Python primitives; one `@Disabled` test documents the known gap that conditions on `typeAlias` definitions are not generated |

### Extended JUnit Test Classes

- **`PythonCollectionExpressionTest`** — added `testSortWithKeyExpression` covering `sorted(..., key=lambda item: rune_resolve_attr(...))` generation for sort operations with an explicit key attribute

---

### New Python Unit Tests

Each entry is a Rune model paired with a pytest file that exercises generated code end-to-end.

| Rosetta model | Test file | What it covers |
|---|---|---|
| `Constructor.rosetta` | `test_constructor.py` | Full and partial constructor expressions; nested list-of-objects constructor |
| `EmptyEvaluation.rosetta` | `test_empty_evaluation.py` | `IsAbsent` / `IsPresent` functions on optional boolean fields; all four absent/present combinations |
| `TypeAliasCondition.rosetta` | `test_type_alias_condition.py` | Documents that type alias conditions are not enforced at runtime; `INVALID` values are accepted without error (known gap) |

### Extended Python Unit Tests

- **`SortClosure.rosetta` / `test_sort_closure.py`** — added `SortItemsBySecondField` (sort by a second attribute), `SortIntegers` (plain sort without a key), and assertions that all non-null items are preserved after sorting

---

### Known Gap Documented

`typeAlias` conditions are not generated in Python. The generator strips all type aliases to their underlying primitive (`str`, `int`, etc.) and discards any `condition` block on the alias. This affects codelist validation (`FpMLCodingScheme` and its derivatives) and is tracked separately. The gap is documented in `PythonTypeAliasConditionTest` (`@Disabled`) and `test_type_alias_condition.py`.
