### PR TITLE
fix: resolve walrus operator SyntaxError using lambda wrappers

### DIFF
--- a/python-test/cdm-tests/test_import_qualification_functions.py
+++ b/python-test/cdm-tests/test_import_qualification_functions.py
@@ -1,0 +1,14 @@
+'''test the generated Python'''
+import pytest
+import logging
+
+# Initialize logger
+logger = logging.getLogger(__name__)
+
+def test_import_qualify_asset_class_foreign_exchange():
+    '''confirm that qualification function can be imported'''
+    try:
+        from finos.cdm.product.qualification.functions.Qualify_AssetClass_ForeignExchange import Qualify_AssetClass_ForeignExchange
+    except ImportError:
+        logger.error(f"Validation failed: {e}")
+        pytest.fail("Importing cdm.product.qualification.functions.Qualify_AssetClass_ForeignExchange failed")

--- a/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.java
@@ -197,7 +197,7 @@ public final class PythonExpressionGenerator {
                 return generateFilterOperation(filter, scope);
             }
             case FirstOperation first -> {
-                return "next((x for x in (" + generateExpression(first.getArgument(), scope) + " or []) if x is not None), None)";
+                return "(lambda items: next((x for x in (items or []) if x is not None), None))(" + generateExpression(first.getArgument(), scope) + ")";
             }
             case FlattenOperation flatten -> {
                 return generateFlattenOperation(flatten, scope);
@@ -296,7 +296,7 @@ public final class PythonExpressionGenerator {
                 return generateFeatureCall(featureCall, scope);
             }
             case RosettaOnlyElement onlyElement -> {
-                return "rune_get_only_element([x for x in (" + generateExpression(onlyElement.getArgument(), scope) + " or []) if x is not None])";
+                return "(lambda items: rune_get_only_element([x for x in (items or []) if x is not None]))(" + generateExpression(onlyElement.getArgument(), scope) + ")";
             }
             case RosettaOnlyExistsExpression onlyExists -> {
                 String args = onlyExists.getArgs().stream()
@@ -353,9 +353,7 @@ public final class PythonExpressionGenerator {
                 path = List.of(targetOption.getName());
             }
             if (isMulti) {
-                // Each step in the path becomes an `if` clause with a walrus assignment,
-                // guarding the next step. Single-step collapses to the existing pattern.
-                StringBuilder sb = new StringBuilder("[_v for _x in (").append(arg).append(" or [])");
+                StringBuilder sb = new StringBuilder("(lambda _items: [_v for _x in _items");
                 String prev = "_x";
                 for (int i = 0; i < path.size(); i++) {
                     String varName = (i == path.size() - 1) ? "_v" : "_t" + i;
@@ -364,7 +362,7 @@ public final class PythonExpressionGenerator {
                       .append(path.get(i)).append("\")) is not None");
                     prev = varName;
                 }
-                sb.append("]");
+                sb.append("])((").append(arg).append(" or []))");
                 return sb.toString();
             }
             // Single: chain rune_resolve_attr calls.
@@ -379,7 +377,7 @@ public final class PythonExpressionGenerator {
         // not a subclass of the wrapped type, so the isinstance check must unwrap first.
         String targetTypeName = ((Data) expr.getType()).getName();
         if (isMulti) {
-            return "[_x for _x in (" + arg + " or []) if isinstance(rune_unwrap(_x), " + targetTypeName + ")]";
+            return "(lambda _items: [_x for _x in _items if isinstance(rune_unwrap(_x), " + targetTypeName + ")])((" + arg + " or []))";
         }
         return "(_x if isinstance(rune_unwrap(_x := (" + arg + ")), " + targetTypeName + ") else None)";
     }
@@ -993,7 +991,7 @@ public final class PythonExpressionGenerator {
     }
 
     private String generateLastOperation(LastOperation last, PythonExpressionScope scope) {
-        return "next((x for x in reversed(" + generateExpression(last.getArgument(), scope) + " or []) if x is not None), None)";
+        return "(lambda items: next((x for x in reversed(items or []) if x is not None), None))(" + generateExpression(last.getArgument(), scope) + ")";
     }
 
     private String generateSumOperation(SumOperation sum, PythonExpressionScope scope) {


### PR DESCRIPTION
## Description
This PR resolves the fatal module-level `SyntaxError` reported in **[RPG I-260](https://github.com/finos/rune-python-generator/issues/260)** by safely wrapping the offending comprehensions in Immediately Invoked Function Expressions (IIFEs) using `lambda`.

### The Problem
Under Python's PEP 572, using an assignment expression (`:=`) inside a comprehension to bind a variable that is simultaneously the target expression—especially at the module level—can violate scope resolution rules, throwing a `SyntaxError: assignment expression cannot be used in a comprehension iterable expression`. This was occurring in the code generated by `AsOperation`, `FirstOperation`, `LastOperation`, and `RosettaOnlyElement`.

More details in **[RPG I-260](https://github.com/finos/rune-python-generator/issues/260)**.

### The Solution
We noticed that `PythonExpressionGenerator.java` already utilizes an elegant `lambda` wrapper mechanism to isolate scopes for other operations (such as `FlattenOperation` and `DistinctOperation`). 

By extending this existing `(lambda items: ...)(arg)` pattern to the remaining list comprehensions and generator expressions, we effectively push the comprehension into a local function scope. This satisfies Python's strict scoping rules for the walrus operator without changing the underlying logical evaluation.

**Example of the generated change:**
*Before:*
```python
[_v for _x in (arg or []) if (_v := rune_resolve_attr(_x, "OptionPayout")) is not None]
```
*After:*
```python
(lambda _items: [_v for _x in _items if (_v := rune_resolve_attr(_x, "OptionPayout")) is not None])((arg or []))
```

### Testing & Next Steps
Included in this PR is a new test script (`test_import_qualification_functions.py`) to verify that the generated qualification function `Qualify_AssetClass_ForeignExchange` can be successfully imported by the Python interpreter without throwing syntax errors.

**Note:** If you run the test suite, this new test currently fails, but *not* due to a `SyntaxError`. The interpreter successfully parses the syntax, but subsequently crashes with a missing import error (`NameError: name 'finos_cdm_product_template_Payout' is not defined`). 

Because this missing import is a separate code generation issue entirely (unrelated to the walrus operator), we have left the test as-is to prove the syntax fix works, and we will be opening a separate issue **[RPG I-263](https://github.com/finos/rune-python-generator/issues/263)** to address the missing import dependencies.