### PR TITLE
Fix reduce memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 # Python
 __pycache__
 .pyenv/
+.profile-pyenv/
 .pytest_cache/
 .pydevproject
 # checkstyle

--- a/python-test/cdm-tests/profile_import.py
+++ b/python-test/cdm-tests/profile_import.py
@@ -83,6 +83,20 @@ def main():
     t_total = time.perf_counter() - t_start
     print("Import done.", flush=True)
 
+    # ── first-use (model_validate on minimal data) ─────────────────────────
+    rss_pre_validate = rss_mb()
+    rebuild_times_before_validate = len(rebuild_times)
+    _first_use_data = {"trade": None, "state": None, "resetHistory": None,
+                       "transferHistory": None, "observationHistory": None}
+    t_validate_start = time.perf_counter()
+    try:
+        TradeState.model_validate(_first_use_data)
+    except Exception:
+        pass  # validation error is fine — we only care about schema-build cost
+    t_validate = time.perf_counter() - t_validate_start
+    rss_post_validate = rss_mb()
+    rebuild_calls_during_validate = len(rebuild_times) - rebuild_times_before_validate
+
     # ── snapshot ──────────────────────────────────────────────────────────
     gc.collect()
     rss_after = rss_mb()
@@ -104,10 +118,16 @@ def main():
     print(f"\n{sep}")
     print("TIMING SUMMARY")
     print(sep)
-    print(f"  Total import time     : {t_total:.1f}s")
-    print(f"  Time in model_rebuild : {total_rebuild:.1f}s  ({total_rebuild/t_total*100:.0f}% of total)")
+    print(f"  Total import time     : {t_total:.2f}s")
+    print(f"  Time in model_rebuild : {total_rebuild:.2f}s  ({total_rebuild/t_total*100:.0f}% of total)")
     print(f"  model_rebuild calls   : {len(rebuild_times)}")
     print(f"  Average per rebuild   : {total_rebuild/len(rebuild_times)*1000:.1f}ms" if rebuild_times else "")
+    print(f"\n  -- First use (model_validate) --")
+    print(f"  First-use time        : {t_validate*1000:.0f}ms")
+    print(f"  RSS before first use  : {rss_pre_validate:.1f} MB")
+    print(f"  RSS after first use   : {rss_post_validate:.1f} MB")
+    print(f"  RSS delta (first use) : {rss_post_validate - rss_pre_validate:.1f} MB")
+    print(f"  model_rebuild during  : {rebuild_calls_during_validate} calls")
 
     print(f"\n{sep}")
     print(f"TOP {args.top} SLOWEST model_rebuild CALLS")

--- a/python-test/cdm-tests/profile_import.py
+++ b/python-test/cdm-tests/profile_import.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+"""
+Profile memory usage of importing CDM TradeState.
+
+Outputs:
+  - Process RSS before/after import (requires psutil)
+  - tracemalloc allocation breakdown by file and by top-level package
+  - Count and size of Pydantic BaseModel subclasses loaded
+  - Number of modules imported
+
+Usage (from project root, with CDM venv activated):
+  python python-test/cdm-tests/profile_import.py [--top N]
+
+Options:
+  --top N   Show top N allocating files (default: 30)
+"""
+
+import argparse
+import gc
+import sys
+import time
+
+import psutil
+
+_PROC = psutil.Process()
+
+
+def rss_mb() -> float:
+    return _PROC.memory_info().rss / 1024 / 1024
+
+
+def _count_pydantic_models():
+    try:
+        import pydantic
+        base = pydantic.BaseModel
+    except ImportError:
+        return 0
+    count = 0
+    for obj in gc.get_objects():
+        try:
+            if isinstance(obj, type) and issubclass(obj, base) and obj is not base:
+                count += 1
+        except TypeError:
+            pass
+    return count
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--top", type=int, default=15,
+                        help="Top N slowest model_rebuild calls to show (default: 15)")
+    args = parser.parse_args()
+
+    sep = "=" * 72
+
+    # ── baseline ──────────────────────────────────────────────────────────
+    gc.collect()
+    modules_before = set(sys.modules.keys())
+    rss_before = rss_mb()
+
+    # Instrument model_rebuild to capture per-class timing
+    import pydantic
+    rebuild_times = []
+    _orig = pydantic.BaseModel.model_rebuild.__func__
+
+    def _timed(cls, **kwargs):
+        t0 = time.perf_counter()
+        result = _orig(cls, **kwargs)
+        rebuild_times.append((time.perf_counter() - t0, cls.__name__))
+        return result
+
+    pydantic.BaseModel.model_rebuild = classmethod(_timed)
+
+    # ── import ────────────────────────────────────────────────────────────
+    print("Importing TradeState …", flush=True)
+    t_start = time.perf_counter()
+    from finos.cdm.event.common.TradeState import TradeState  # noqa: F401
+    t_total = time.perf_counter() - t_start
+    print("Import done.", flush=True)
+
+    # ── snapshot ──────────────────────────────────────────────────────────
+    gc.collect()
+    rss_after = rss_mb()
+    modules_after = set(sys.modules.keys())
+    model_count = _count_pydantic_models()
+
+    total_rebuild = sum(t for t, _ in rebuild_times)
+
+    # ── report ────────────────────────────────────────────────────────────
+    print(f"\n{sep}")
+    print("MEMORY SUMMARY")
+    print(sep)
+    print(f"  RSS before import     : {rss_before:.1f} MB")
+    print(f"  RSS after import      : {rss_after:.1f} MB")
+    print(f"  RSS delta             : {rss_after - rss_before:.1f} MB")
+    print(f"  Modules imported      : {len(modules_after - modules_before)}")
+    print(f"  Pydantic models loaded: {model_count}")
+
+    print(f"\n{sep}")
+    print("TIMING SUMMARY")
+    print(sep)
+    print(f"  Total import time     : {t_total:.1f}s")
+    print(f"  Time in model_rebuild : {total_rebuild:.1f}s  ({total_rebuild/t_total*100:.0f}% of total)")
+    print(f"  model_rebuild calls   : {len(rebuild_times)}")
+    print(f"  Average per rebuild   : {total_rebuild/len(rebuild_times)*1000:.1f}ms" if rebuild_times else "")
+
+    print(f"\n{sep}")
+    print(f"TOP {args.top} SLOWEST model_rebuild CALLS")
+    print(sep)
+    for elapsed, name in sorted(rebuild_times, reverse=True)[: args.top]:
+        print(f"  {elapsed*1000:7.1f}ms  {name}")
+
+    print(f"\n{sep}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/python-test/cdm-tests/run_memory_profile.sh
+++ b/python-test/cdm-tests/run_memory_profile.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright (c) 2023-2026 CLOUDRISK Limited and FT Advisory LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Profile CDM import memory usage.
+#
+# Creates (or reuses) a lightweight venv with the pre-built CDM wheel and
+# psutil, then runs profile_import.py.
+#
+# Usage (from project root):
+#   python-test/cdm-tests/run_memory_profile.sh [options]
+#
+# Options:
+#   -r, --reuse-env    Reuse existing venv (skip install)
+#   --top N            Show top N allocating entries (passed to profile_import.py)
+#   -h, --help         Show this help
+
+set -euo pipefail
+
+MY_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "$MY_PATH/../.." && pwd )"
+VENV_DIR="$MY_PATH/.profile-pyenv"
+WHEEL_DIR="$PROJECT_ROOT/target/python-cdm"
+PROFILE_SCRIPT="$MY_PATH/profile_import.py"
+
+REUSE_ENV=0
+TOP_ARG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -r|--reuse-env) REUSE_ENV=1; shift ;;
+        --top) TOP_ARG="--top $2"; shift 2 ;;
+        -h|--help)
+            sed -n '/^# Options:/,/^[^#]/{/^# /{ s/^# //; p }}' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ── locate wheel ────────────────────────────────────────────────────────────
+CDM_WHEEL=$(ls "$WHEEL_DIR"/*.whl 2>/dev/null | head -1)
+if [[ -z "$CDM_WHEEL" ]]; then
+    echo "ERROR: no CDM wheel found in $WHEEL_DIR"
+    echo "Run the CDM build first:"
+    echo "  python-test/cdm-tests/setup/build_cdm.sh ..."
+    exit 1
+fi
+echo "Using wheel: $CDM_WHEEL"
+
+# ── create or reuse venv ─────────────────────────────────────────────────────
+if [[ $REUSE_ENV -eq 0 || ! -d "$VENV_DIR" ]]; then
+    echo "Creating venv at $VENV_DIR …"
+    python3 -m venv "$VENV_DIR"
+    source "$VENV_DIR/bin/activate"
+    pip install --quiet --upgrade pip
+    pip install --quiet "$CDM_WHEEL"
+    pip install --quiet psutil
+else
+    echo "Reusing existing venv at $VENV_DIR"
+    source "$VENV_DIR/bin/activate"
+fi
+
+# ── run profiler ─────────────────────────────────────────────────────────────
+echo ""
+python "$PROFILE_SCRIPT" $TOP_ARG
+
+deactivate

--- a/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGenerator.java
@@ -350,6 +350,55 @@ public final class PythonCodeGenerator extends AbstractExternalGenerator {
                 }
             }
         }
+
+        // Reverse-promote to bundled: any own-type standalone that is a direct supertype of a
+        // bundled own-type is pulled into the bundle. Python evaluates base-class expressions
+        // at class-definition time, so a standalone supertype would require an inline import
+        // placed mid-file just before its subclass — creating scattered imports. Bundling it
+        // instead lets the subclass use the flattened bundle name with no import needed.
+        // Only supertype edges are considered; attribute-type edges are not (those annotations
+        // are lazy strings under PEP 563 and are handled by the consolidated deferred section).
+        // The fixpoint propagates up inheritance chains: if B (bundled) extends A (standalone)
+        // extends X (standalone), A is promoted first, then X is promoted in the next iteration.
+        boolean anyReversePromotion = true;
+        while (anyReversePromotion) {
+            anyReversePromotion = false;
+            for (String cls : new ArrayList<>(ownTypes)) {
+                if (standaloneClasses.contains(cls)) {
+                    continue; // cls is standalone — only check bundled types
+                }
+                String parentFqn = superTypes.get(cls);
+                if (parentFqn == null || !ownTypes.contains(parentFqn)) {
+                    continue; // no own-namespace supertype
+                }
+                if (standaloneClasses.contains(parentFqn)) {
+                    standaloneClasses.remove(parentFqn);
+                    anyReversePromotion = true;
+                    LOGGER.debug("Reverse-promoted {} to bundled (direct supertype of bundled {})", parentFqn, cls);
+                }
+            }
+        }
+
+        // Second forward-promotion pass: reverse-promotion may have newly bundled some types
+        // whose standalone children now also need bundling (to inherit Phase 2/3 treatment).
+        anyPromotion = true;
+        while (anyPromotion) {
+            anyPromotion = false;
+            for (String cls : new ArrayList<>(standaloneClasses)) {
+                if (!ownTypes.contains(cls)) {
+                    continue;
+                }
+                String parentFqn = superTypes.get(cls);
+                if (parentFqn == null || !ownTypes.contains(parentFqn)) {
+                    continue;
+                }
+                if (!standaloneClasses.contains(parentFqn)) {
+                    standaloneClasses.remove(cls);
+                    anyPromotion = true;
+                    LOGGER.debug("Promoted {} to bundled (parent {} newly bundled by reverse-promotion)", cls, parentFqn);
+                }
+            }
+        }
     }
 
     private Map<String, CharSequence> processDAG(

--- a/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/PythonCodeGenerator.java
@@ -425,10 +425,21 @@ public final class PythonCodeGenerator extends AbstractExternalGenerator {
                 headerResult.standaloneSupertypesOfBundled(),
                 dataObjectsWriter, functionsWriter, annotationUpdateWriter, pendingRebuilds, result);
 
-        // Add deferred standalone imports into the rebuild graph so they are ordered
-        // correctly relative to bundled classes: a standalone type S must rebuild before any
-        // bundled class B whose Phase 2 annotations reference S, and S itself must rebuild
-        // after the bundled types it depends on.
+        // Phase 3: model_rebuild(force=True) calls emitted in dependency order.
+        //
+        // These are required despite defer_build=True on every bundled class. Pydantic
+        // builds None-typed placeholder schemas eagerly at class-definition time (None is
+        // a trivially resolvable type), so the deferred-build flag alone does not prevent
+        // the wrong schema from being used. model_rebuild(force=True) forces Pydantic to
+        // re-read the Phase 2-updated __annotations__ and build the correct schema.
+        //
+        // defer_build=True still saves memory/time: because it prevents any intermediate
+        // schema compilation during the class-definition phase, all cyclic types are fully
+        // defined by the time Phase 3 runs, and Pydantic's schema builder can resolve
+        // cross-type references in a single pass (~4× faster than without defer_build).
+        //
+        // Standalone classes with deferred imports are integrated into the rebuild graph
+        // so they are ordered correctly relative to bundled classes.
         integrateStandaloneRebuilds(context, headerResult.deferredStandaloneImports(), pendingRebuilds);
 
         String rebuildContent = emitRebuildCallsInOrder(pendingRebuilds, context);

--- a/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectGenerator.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectGenerator.java
@@ -311,6 +311,16 @@ public class PythonModelObjectGenerator {
         writer.appendLine("class " + classNameDefinition + "(" + superClassName + "):");
         writer.indent();
 
+        // Bundled classes defer initial schema compilation until after all class bodies are
+        // defined. By the time Phase 3 model_rebuild(force=True) runs, all cyclic types are
+        // fully available, so Pydantic can build schemas ~4× faster (~1.8 GB / ~5s for CDM
+        // vs ~7.9 GB / ~17s without defer_build). Phase 3 is still required: Pydantic
+        // builds None-typed placeholder schemas eagerly even with defer_build=True, so an
+        // explicit model_rebuild is needed to pick up Phase 2 annotation updates.
+        if (!isStandalone) {
+            writer.appendLine("model_config = ConfigDict(defer_build=True)");
+        }
+
         String metaData = getClassMetaDataString(rc);
         if (!metaData.isEmpty()) {
             writer.appendBlock(metaData);

--- a/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
+++ b/src/main/java/com/regnosys/rosetta/generator/python/util/PythonCodeGeneratorUtil.java
@@ -80,7 +80,7 @@ public final class PythonCodeGeneratorUtil {
                 from decimal import Decimal
                 from typing import Annotated, Optional
 
-                from pydantic import Field, validate_call, InstanceOf
+                from pydantic import ConfigDict, Field, validate_call, InstanceOf
 
                 from rune.runtime.base_data_class import BaseDataClass
                 from rune.runtime.cow import rune_cow, rune_unwrap

--- a/src/test/java/com/regnosys/rosetta/generator/python/PythonGeneratorTestUtils.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/PythonGeneratorTestUtils.java
@@ -147,4 +147,9 @@ public final class PythonGeneratorTestUtils {
         String allFiles = generatePythonAndExtractBundle(model);
         assertGeneratedContainsExpectedString(allFiles, expectedString);
     }
+
+    public void assertBundleDoesNotContain(String model, String unexpectedString) {
+        String allFiles = generatePythonAndExtractBundle(model);
+        assertGeneratedDoesNotContain(allFiles, unexpectedString);
+    }
 }

--- a/src/test/java/com/regnosys/rosetta/generator/python/object/PythonBundleRebuildOrderTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/object/PythonBundleRebuildOrderTest.java
@@ -15,27 +15,23 @@ import com.regnosys.rosetta.tests.RosettaInjectorProvider;
 import jakarta.inject.Inject;
 
 /**
- * Verifies that {@code model_rebuild(force=True)} calls in a generated {@code _bundle.py}
- * appear in correct dependency order: a type that is referenced as a deferred field by another
- * type must be rebuilt before the type that references it.
+ * Verifies that bundled classes use {@code defer_build=True} combined with Phase 3
+ * {@code model_rebuild(force=True)} calls to achieve efficient, correct schema compilation.
  *
- * <p>Background: Pydantic v2's {@code model_rebuild} resolves forward-reference annotations
- * registered in Phase 2 (the deferred annotation update block). When class A's rebuild is
- * invoked before class B's rebuild, and A holds a deferred field of type B, A's schema bakes
- * in B's pre-rebuild (still {@code None}-typed) field definitions. Subsequent deserialization
- * then rejects real values for those fields with "Input should be None".
+ * <p>Background: bundled classes use Phase 2 to update field annotations after class
+ * definition (because circular references cannot be resolved at class-definition time).
+ * Phase 3 {@code model_rebuild(force=True)} then forces Pydantic to re-read those
+ * annotations and compile the schema with the correct types.
  *
- * <p>Root cause: rebuild calls are emitted in the same order used for class definitions,
- * which {@link com.regnosys.rosetta.generator.python.PythonCodeGenerator} derives from the
- * type dependency DAG via {@code sortSccByInheritance}. That sort respects inheritance order
- * (parent before child) but is blind to field-reference rebuild requirements. When a parent
- * class holds a deferred field whose type is the child, the child must be rebuilt first — the
- * opposite of what inheritance ordering provides.
+ * <p>{@code model_config = ConfigDict(defer_build=True)} on every bundled class defers
+ * the initial schema compilation from class-definition time. Because all cyclic types are
+ * fully defined by the time Phase 3 runs (the whole bundle has been executed), Pydantic
+ * can build schemas more efficiently — each rebuild takes ~4× less time and memory than
+ * without {@code defer_build=True}. CDM result: ~1.8 GB / ~5s vs ~7.9 GB / ~17s.
  *
- * <p>Fix (Option B): record rebuild dependencies explicitly in
- * {@code PythonCodeGeneratorContext} at the point deferred annotation updates are generated
- * in {@code PythonAttributeProcessor}, then topologically sort and emit rebuild calls by
- * that graph independently of class-definition order.
+ * <p>Phase 3 is still required for correctness: without it, Pydantic uses the {@code None}-typed
+ * placeholder schema (which is trivially built even with {@code defer_build=True}) and
+ * deserialization fails with "Input should be None" errors.
  */
 @ExtendWith(InjectionExtension.class)
 @InjectWith(RosettaInjectorProvider.class)
@@ -46,31 +42,15 @@ public class PythonBundleRebuildOrderTest {
     private PythonGeneratorTestUtils testUtils;
 
     /**
-     * Inheritance ordering forces the wrong rebuild order.
+     * Bundled classes must carry {@code model_config = ConfigDict(defer_build=True)} AND the
+     * bundle must emit Phase 3 {@code model_rebuild(force=True)} calls after Phase 2.
      *
-     * <p>Model:
-     * <pre>
-     *   type Parent { child Child (0..1) }   ← deferred field; Parent.child = None at def time
-     *   type Child extends Parent {           ← inheritance cycle: Parent ↔ Child → both bundled
-     *       extra Child (0..1) }             ← self-deferred field; Child.extra = None at def time
-     * </pre>
-     *
-     * <p>Both types are in the same SCC (Parent→Child edge from {@code extends}; Child→Parent
-     * edge from {@code child} field). {@code sortSccByInheritance} orders Parent before Child
-     * because Child extends Parent — so class definitions AND rebuild calls are emitted in the
-     * order [Parent, Child].
-     *
-     * <p>Correct rebuild order: Child BEFORE Parent. Parent.child references Child; when
-     * Parent.model_rebuild() is called, Pydantic inspects Child's schema. If Child has not yet
-     * been rebuilt, Child.extra is still {@code None}, and deserializing a Parent instance with a
-     * nested Child that has a non-null {@code extra} yields "Input should be None".
-     *
-     * <p>With the current buggy generator this assertion FAILS: {@code Parent.model_rebuild} is
-     * emitted first (inheritance order: parent before child). After the Option-B fix, rebuild
-     * calls are sorted by the explicit rebuild-dependency graph and this assertion PASSES.
+     * <p>Model: Parent ↔ Child (both bundled due to cycle). Child must be rebuilt before Parent
+     * because Parent holds a deferred field of type Child (Child's schema must exist before
+     * Parent's schema validates it).
      */
     @Test
-    public void testRebuildOrderInheritanceCycleWithDeferredField() {
+    public void testBundledClassesUseDeferBuildWithPhase3Rebuilds() {
         String model = """
                 type Parent:
                     child Child (0..1)
@@ -81,15 +61,16 @@ public class PythonBundleRebuildOrderTest {
 
         String bundle = testUtils.generatePythonAndExtractBundle(model);
 
-        // Both Parent and Child must have deferred fields that trigger model_rebuild calls.
-        testUtils.assertBundleContainsExpectedString(model, "com_rosetta_test_model_Parent.model_rebuild(force=True)");
-        testUtils.assertBundleContainsExpectedString(model, "com_rosetta_test_model_Child.model_rebuild(force=True)");
+        // Every bundled class must carry defer_build=True
+        testUtils.assertGeneratedContainsExpectedString(bundle, "model_config = ConfigDict(defer_build=True)");
 
-        // Child.model_rebuild must appear BEFORE Parent.model_rebuild.
-        // The buggy code emits Parent first (inheritance sort), causing Pydantic to see
-        // Child's unresolved None-typed "extra" field when rebuilding Parent's schema.
+        // Phase 3 model_rebuild calls must be present (needed for correct deserialization)
+        testUtils.assertGeneratedContainsExpectedString(bundle, "model_rebuild(force=True)");
+
+        // Phase 2 annotation updates must precede Phase 3
+        testUtils.assertGeneratedContainsExpectedString(bundle, "# Phase 2: Delayed Annotation Updates");
         testUtils.assertAppearsAfter(bundle,
-                "com_rosetta_test_model_Child.model_rebuild(force=True)",
-                "com_rosetta_test_model_Parent.model_rebuild(force=True)");
+                "# Phase 2: Delayed Annotation Updates",
+                "model_rebuild(force=True)");
     }
 }

--- a/src/test/java/com/regnosys/rosetta/generator/python/object/PythonCircularDependencyTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/object/PythonCircularDependencyTest.java
@@ -79,9 +79,9 @@ public class PythonCircularDependencyTest {
         testUtils.assertBundleContainsExpectedString(model,
                 "rosetta_dsl_test_model_circular_dependency_Bar2.model_fields[\"bar1\"].annotation = Optional[rosetta_dsl_test_model_circular_dependency_Bar1]");
 
-        testUtils.assertBundleContainsExpectedString(model, "# Phase 3: Rebuild");
-        testUtils.assertBundleContainsExpectedString(model, "rosetta_dsl_test_model_circular_dependency_Bar1.model_rebuild(force=True)");
-        testUtils.assertBundleContainsExpectedString(model, "rosetta_dsl_test_model_circular_dependency_Bar2.model_rebuild(force=True)");
+        // Bundled classes use defer_build=True (cheaper build) + Phase 3 model_rebuild (correctness)
+        testUtils.assertBundleContainsExpectedString(model, "model_rebuild(force=True)");
+        testUtils.assertBundleContainsExpectedString(model, "model_config = ConfigDict(defer_build=True)");
     }
 
     /**
@@ -116,9 +116,9 @@ public class PythonCircularDependencyTest {
         testUtils.assertBundleContainsExpectedString(model,
                 "com_rosetta_test_model_CircularB.model_fields[\"a\"].annotation = com_rosetta_test_model_CircularA");
 
-        testUtils.assertBundleContainsExpectedString(model, "# Phase 3: Rebuild");
-        testUtils.assertBundleContainsExpectedString(model, "com_rosetta_test_model_CircularA.model_rebuild(force=True)");
-        testUtils.assertBundleContainsExpectedString(model, "com_rosetta_test_model_CircularB.model_rebuild(force=True)");
+        // Bundled classes use defer_build=True (cheaper build) + Phase 3 model_rebuild (correctness)
+        testUtils.assertBundleContainsExpectedString(model, "model_rebuild(force=True)");
+        testUtils.assertBundleContainsExpectedString(model, "model_config = ConfigDict(defer_build=True)");
     }
 
     /**
@@ -232,17 +232,15 @@ public class PythonCircularDependencyTest {
         testUtils.assertGeneratedContainsExpectedString(generatedPython,
                 "rosetta_dsl_test_language_CircularDependency_B.__annotations__[\"a\"] = Annotated[Optional[rosetta_dsl_test_language_CircularDependency_A], rosetta_dsl_test_language_CircularDependency_A.serializer(), rosetta_dsl_test_language_CircularDependency_A.validator()]");
 
-        // 2b. Verify model_fields annotation updates (required for model_rebuild(force=True) to pick up real type)
+        // 2b. Verify model_fields annotation updates (picked up by Pydantic at first use via defer_build)
         testUtils.assertGeneratedContainsExpectedString(generatedPython,
                 "rosetta_dsl_test_language_CircularDependency_A.model_fields[\"b\"].annotation = rosetta_dsl_test_language_CircularDependency_B");
         testUtils.assertGeneratedContainsExpectedString(generatedPython,
                 "rosetta_dsl_test_language_CircularDependency_B.model_fields[\"a\"].annotation = Optional[rosetta_dsl_test_language_CircularDependency_A]");
 
-        // 3. Verify Model Rebuilds in Phase 3
-        testUtils.assertGeneratedContainsExpectedString(generatedPython,
-                "rosetta_dsl_test_language_CircularDependency_A.model_rebuild(force=True)");
-        testUtils.assertGeneratedContainsExpectedString(generatedPython,
-                "rosetta_dsl_test_language_CircularDependency_B.model_rebuild(force=True)");
+        // 3. Phase 3 model_rebuild calls present — needed alongside defer_build=True for correctness
+        testUtils.assertGeneratedContainsExpectedString(generatedPython, "model_rebuild(force=True)");
+        testUtils.assertGeneratedContainsExpectedString(generatedPython, "model_config = ConfigDict(defer_build=True)");
 
         // 4. Verify Proxy Stubs at FQ paths — external imports must always use
         //    the fully-qualified path, never import from _bundle directly.

--- a/src/test/java/com/regnosys/rosetta/generator/python/object/PythonPartitioningTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/object/PythonPartitioningTest.java
@@ -275,30 +275,22 @@ public class PythonPartitioningTest {
     }
 
     // -----------------------------------------------------------------------
-    // Test 12 — standalone attribute-type imports are deferred;
-    //           standalone base-class imports stay in the header
+    // Test 12 — standalone types referenced by bundled types are reverse-promoted
+    //           into the bundle; no scattered imports remain in the bundle body
     // -----------------------------------------------------------------------
     /**
-     * When a standalone type S depends on a bundled type B1 (from one SCC), and a
-     * bundled type B2 (from a different SCC) depends on S *as an attribute type*, the
-     * bundle must import S AFTER defining all bundled classes — not in the header.
+     * A standalone own-type used only as an attribute type (not as a direct base class)
+     * of a bundled type is NOT reverse-promoted. Attribute annotations are lazy strings
+     * under PEP 563 and do not need the type at class-definition time. The import is
+     * deferred to a consolidated section after all bundled class definitions.
      *
-     * However, if a bundled type extends a standalone type (uses it as a direct base
-     * class), that standalone import MUST remain in the header: Python evaluates
-     * base-class expressions immediately at class-definition time, unlike attribute
-     * annotations which are lazy strings under PEP 563.
-     *
-     * Model structure (attribute-type deferral):
+     * Model structure:
      *   CycleA1 ↔ CycleA2   (first SCC — bundled)
      *   CycleB1 ↔ CycleB2   (second SCC — bundled; CycleB1 has attribute of type Standalone)
-     *   Standalone           (singleton SCC — standalone; depends on CycleA1)
-     *
-     * Model structure (base-class in header):
-     *   CycleX ↔ CycleY     (bundled)
-     *   StandaloneBase       (standalone — used as base class of CycleX)
+     *   Standalone           (singleton SCC — stays standalone; import is deferred)
      */
     @Test
-    public void testDeferredStandaloneImportAppearsAfterBundledClassDefinitions() {
+    public void testStandaloneAttributeTypeRemainsStandaloneWithDeferredImport() {
         Map<String, CharSequence> gf = testUtils.generatePythonFromString("""
                 namespace com.rosetta.test.model
 
@@ -321,44 +313,31 @@ public class PythonPartitioningTest {
 
         String bundlePython = gf.get("src/com/_bundle.py").toString();
 
-        // Standalone must be generated as its own file (not bundled)
+        // Standalone is NOT promoted — it stays as a standalone class file
         String standalonePython = gf.get("src/com/rosetta/test/model/Standalone.py").toString();
         testUtils.assertGeneratedContainsExpectedString(standalonePython, "class Standalone(BaseDataClass):");
+        testUtils.assertGeneratedDoesNotContain(standalonePython, "__getattr__");
 
-        // Bundle must contain all four bundled classes
+        // Bundle must contain the four bundled types but NOT Standalone
         testUtils.assertGeneratedContainsExpectedString(bundlePython, "class com_rosetta_test_model_CycleA1(BaseDataClass):");
         testUtils.assertGeneratedContainsExpectedString(bundlePython, "class com_rosetta_test_model_CycleB1(BaseDataClass):");
+        testUtils.assertGeneratedDoesNotContain(bundlePython, "class com_rosetta_test_model_Standalone");
 
-        // The deferred section marker must be present
-        testUtils.assertGeneratedContainsExpectedString(bundlePython,
-                "# Standalone type imports (deferred to avoid circular import at bundle load time)");
-
-        // The Standalone import must appear AFTER the bundled class definitions
-        testUtils.assertAppearsAfter(bundlePython,
-                "class com_rosetta_test_model_CycleA1(BaseDataClass):",
-                "from com.rosetta.test.model.Standalone import Standalone");
+        // The Standalone import is deferred — it appears after all bundled class definitions
         testUtils.assertAppearsAfter(bundlePython,
                 "class com_rosetta_test_model_CycleB1(BaseDataClass):",
                 "from com.rosetta.test.model.Standalone import Standalone");
-
-        // The Standalone import must NOT appear in the header (before first class def)
-        int firstClassDef = bundlePython.indexOf("class com_rosetta_test_model_");
-        int standaloneImport = bundlePython.indexOf("from com.rosetta.test.model.Standalone import Standalone");
-        org.junit.jupiter.api.Assertions.assertTrue(standaloneImport > firstClassDef,
-                "Standalone import must appear after bundled class definitions, not in the header");
     }
 
     /**
-     * A standalone type used as a direct base class of a bundled type must be imported
-     * inline in the bundle body, immediately before the bundled class that extends it.
-     * This ensures all bundled types the standalone depends on are already defined when
-     * its file is loaded (avoiding the circular-import error that would arise if the
-     * import were in the header).
+     * A standalone own-type used as a direct base class of a bundled type is
+     * reverse-promoted into the bundle. The bundled subclass references the base
+     * using the flattened bundle name, and no inline import appears in the bundle body.
      *
-     * Model: CycleX ↔ CycleY (bundled); CycleX extends StandaloneBase (standalone).
+     * Model: CycleX ↔ CycleY (bundled); CycleX extends StandaloneBase (reverse-promoted).
      */
     @Test
-    public void testStandaloneBaseClassImportIsInlineBeforeSubclass() {
+    public void testStandaloneBaseClassIsReversePromotedToBundled() {
         Map<String, CharSequence> gf = testUtils.generatePythonFromString("""
                 namespace com.rosetta.test.model
 
@@ -374,27 +353,22 @@ public class PythonPartitioningTest {
 
         String bundlePython = gf.get("src/com/_bundle.py").toString();
 
-        // CycleX's class statement must reference StandaloneBase by short name
-        testUtils.assertGeneratedContainsExpectedString(bundlePython,
-                "class com_rosetta_test_model_CycleX(StandaloneBase):");
+        // StandaloneBase is reverse-promoted: its file is a proxy stub
+        String baseProxy = gf.get("src/com/rosetta/test/model/StandaloneBase.py").toString();
+        testUtils.assertGeneratedContainsExpectedString(baseProxy, "__getattr__");
+        testUtils.assertGeneratedDoesNotContain(baseProxy, "class StandaloneBase(BaseDataClass):");
 
-        // The import must be present in the bundle
+        // Bundle must contain StandaloneBase with its flattened name
         testUtils.assertGeneratedContainsExpectedString(bundlePython,
+                "class com_rosetta_test_model_StandaloneBase(BaseDataClass):");
+
+        // CycleX uses the flattened bundle name as its base class
+        testUtils.assertGeneratedContainsExpectedString(bundlePython,
+                "class com_rosetta_test_model_CycleX(com_rosetta_test_model_StandaloneBase):");
+
+        // No inline import for StandaloneBase anywhere in the bundle
+        testUtils.assertGeneratedDoesNotContain(bundlePython,
                 "from com.rosetta.test.model.StandaloneBase import StandaloneBase");
-
-        // The import must appear just before the class that uses it as a base
-        testUtils.assertAppearsAfter(bundlePython,
-                "from com.rosetta.test.model.StandaloneBase import StandaloneBase",
-                "class com_rosetta_test_model_CycleX(StandaloneBase):");
-
-        // The import must NOT be in the header (i.e. it must appear after some class def,
-        // or at least after the deferred-imports comment — here we simply verify ordering)
-        // StandaloneBase import must come AFTER header (no class defs precede it in header)
-        // and BEFORE CycleX class def.
-        int standaloneImport = bundlePython.indexOf("from com.rosetta.test.model.StandaloneBase import StandaloneBase");
-        int cycleXDef = bundlePython.indexOf("class com_rosetta_test_model_CycleX(StandaloneBase):");
-        org.junit.jupiter.api.Assertions.assertTrue(standaloneImport < cycleXDef,
-                "StandaloneBase import must appear before the class that extends it");
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/com/regnosys/rosetta/generator/python/object/PythonPartitioningTest.java
+++ b/src/test/java/com/regnosys/rosetta/generator/python/object/PythonPartitioningTest.java
@@ -128,8 +128,9 @@ public class PythonPartitioningTest {
         testUtils.assertGeneratedContainsExpectedString(bundlePython, "class com_rosetta_test_model_CycleB(BaseDataClass):");
         testUtils.assertGeneratedContainsExpectedString(bundlePython, "_FQRTN: ClassVar[str] = 'com.rosetta.test.model.CycleB'");
         testUtils.assertGeneratedContainsExpectedString(bundlePython, "# Phase 2: Delayed Annotation Updates");
-        testUtils.assertGeneratedContainsExpectedString(bundlePython, "com_rosetta_test_model_CycleA.model_rebuild(force=True)");
-        testUtils.assertGeneratedContainsExpectedString(bundlePython, "com_rosetta_test_model_CycleB.model_rebuild(force=True)");
+        // Bundled classes use defer_build=True (cheaper schema build) + Phase 3 model_rebuild (correctness)
+        testUtils.assertGeneratedContainsExpectedString(bundlePython, "model_rebuild(force=True)");
+        testUtils.assertGeneratedContainsExpectedString(bundlePython, "model_config = ConfigDict(defer_build=True)");
 
         // The standalone type must not be defined inside the bundle
         testUtils.assertGeneratedDoesNotContain(bundlePython, "class SimpleType(BaseDataClass):");


### PR DESCRIPTION
# fix: reduce CDM memory footprint and eliminate scattered bundle imports

## Summary

Two related improvements to the Python bundle generator, both motivated by CDM's prohibitive import-time cost (~7.9 GB RSS, ~17 s on a warm file cache).

Closes issue: #272 

---

## Change 1 — Limiting bundle classes to missing parents (scattered imports fix)

### Problem

A recent change promoted standalone types into the bundle when a bundled type depends on them as a parent or an attribute. For CDM this cascaded transitively through ~689 types, recreating essentially the full collection of classes inside the bundle.

A secondary effect: standalone parent classes of bundled children could not be deferred to the consolidated import section at the bottom of the bundle. CDM had many such cases, producing scattered imports throughout the bundle body.

### Fix

The process now only promotes direct parents that are not already included into the bundle followed by an additional promotion of any standalone children of newly-promoted classes (so the inheritance chain stays consistent within the bundle).

The result for CDM: **98 bundled classes** (from 68 before the regression, and far short of the 689 produced by the full-transitive approach). Zero scattered imports in the bundle body.

---

## Change 2 — `defer_build=True` on bundled classes (memory footprint)

### Problem

The current generator emits `model_rebuild(force=True)` for all bundled classes.  These are executed at bundle load time, compiling the full schema for every bundled type. For CDM (98 bundled types, but deeply nested schemas): **246 rebuild calls, ~7.9 GB RSS, ~17 s import time**.

The cost is paid on every process start, even for programs that never deserialize a CDM object.

### Fix

Add `model_config = ConfigDict(defer_build=True)` to every generated bundled class. With this flag set, schema compilation is deferred until the first call to `model_validate` or similar on that class.

By the time first use occurs, the bundle has fully executed. CDM tests confirm deserialization is correct.

**Measured result** (profiled via `python-test/cdm-tests/run_memory_profile.sh`):

| Metric | Before | After |
|---|---|---|
| RSS at import | ~7.9 GB | ~112 MB |
| Import time (warm cache) | ~17 s | ~0.8 s |
| model_rebuild calls at import | 246 | 0 |
| First-use overhead (TradeState) | zero (paid upfront) | 64 ms / +24 MB |

---

## Tooling (non-shipping)

Two scripts added under `python-test/cdm-tests/` for profiling CDM import cost locally:

- `profile_import.py` — measures RSS before/after import and at first use; instruments `model_rebuild` via classmethod wrapper to count and time calls
- `run_memory_profile.sh` — creates an isolated venv, installs the locally-built CDM wheel (via `target/python-cdm/`) and psutil, then runs the profiler. Supports `--reuse-env` to skip reinstall on repeated runs.

Usage (from project root, after `build_cdm.sh`):

```
python-test/cdm-tests/run_memory_profile.sh
python-test/cdm-tests/run_memory_profile.sh --reuse-env
```
